### PR TITLE
fix: 修复 sentry release 缺失的问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN poetry export -f requirements.txt --output requirements.txt --without-hashes
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim
 
 ENV TZ Asia/Shanghai
+ENV SENTRY_RELEASE=version
 
 WORKDIR /app
 


### PR DESCRIPTION
Sentry 上一直都没显示版本号，居然没注意到。