### PR TITLE
feat: 复读插件支持排除指定用户

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Added
 
 - 添加壁画插件
+- 复读插件支持排除指定用户
 
 ## [0.23.1] - 2025-06-06
 

--- a/src/plugins/repeat/config.py
+++ b/src/plugins/repeat/config.py
@@ -13,6 +13,12 @@ class Config(BaseModel):
     repeat_migration_group_id: int | None = None
     """ 旧数据迁移的群号 """
 
+    repeat_excluded_users: list[str | int] = []
+    """ 排除复读的用户列表
+
+    支持用户名或用户 ID
+    """
+
 
 global_config = get_driver().config
 plugin_config = get_plugin_config(Config)

--- a/src/plugins/repeat/plugins/repeat_basic/repeat_rule.py
+++ b/src/plugins/repeat/plugins/repeat_basic/repeat_rule.py
@@ -5,14 +5,19 @@ from datetime import datetime, timedelta
 
 from nonebot.adapters import Event
 from nonebot.log import logger
+from nonebot_plugin_user import UserSession
 
 from src.plugins.repeat import plugin_config
 from src.plugins.repeat.recorder import Recorder
 from src.utils.annotated import GroupInfo
 
 
-async def need_repeat(event: Event, group_info: GroupInfo) -> bool:
+async def need_repeat(event: Event, group_info: GroupInfo, user: UserSession) -> bool:
     """是否复读这个消息"""
+    # 不复读配置中排除的用户
+    if user.user_name in plugin_config.repeat_excluded_users or user.user_id in plugin_config.repeat_excluded_users:
+        return False
+
     # 不复读对机器人说的，因为这个应该由闲聊插件处理
     if event.is_tome():
         return False


### PR DESCRIPTION
可以通过用户名或者用户 ID 来排除，因为其中一个是 str，另一个是 int，也不会冲突。