### PR TITLE
fix(user): 修复新用户创建失败的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复新用户创建失败的问题
+
 ## [0.26.0] - 2025-08-14
 
 ### Added

--- a/src/utils/user.py
+++ b/src/utils/user.py
@@ -6,13 +6,13 @@ require("nonebot_plugin_user")
 require("src.utils.group_bind")
 from nonebot.params import Depends
 from nonebot_plugin_uninfo import Session, get_session
+from nonebot_plugin_user import User
 from nonebot_plugin_user.models import UserSession as _UserSession
-from nonebot_plugin_user.params import get_user
 
 from src.utils.group_bind import group_bind_service
 
 
-async def get_user_session(session: Session | None = Depends(get_session)):
+async def get_user_session(user: User, session: Session | None = Depends(get_session)):
     """获取用户会话"""
     if session is None:
         return None
@@ -20,7 +20,6 @@ async def get_user_session(session: Session | None = Depends(get_session)):
     session_id = f"{session.scope}_{session.scene_path}"
     session_id = await group_bind_service.get_bind_id(session_id)
 
-    user = await get_user(session)
     if user:
 
         class NewUserSession(_UserSession):


### PR DESCRIPTION
```log
08-16 12:29:57 [ERROR] nonebot | Rule check failed for AlconnaMatcherMeta(type='', command=Alconna::bihua_delete, module=src.plugins.bihua, lineno=206).
  + Exception Group Traceback (most recent call last):
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\bot.py", line 43, in <module>
  |     nonebot.run(app="__mp_main__:app")
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\__init__.py", line 337, in run
  |     get_driver().run(*args, **kwargs)
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\drivers\fastapi.py", line 187, in run
  |     uvicorn.run(
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\uvicorn\main.py", line 580, in run
  |     server.run()
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\uvicorn\server.py", line 67, in run
  |     return asyncio.run(self.serve(sockets=sockets))
  |   File "C:\Users\hmy01\AppData\Roaming\uv\python\cpython-3.13.6-windows-x86_64-none\Lib\asyncio\runners.py", line 195, in run
  |     return runner.run(main)
  |   File "C:\Users\hmy01\AppData\Roaming\uv\python\cpython-3.13.6-windows-x86_64-none\Lib\asyncio\runners.py", line 118, in run
  |     return self._loop.run_until_complete(task)
  |   File "C:\Users\hmy01\AppData\Roaming\uv\python\cpython-3.13.6-windows-x86_64-none\Lib\asyncio\base_events.py", line 712, in run_until_complete
  |     self.run_forever()
  |   File "C:\Users\hmy01\AppData\Roaming\uv\python\cpython-3.13.6-windows-x86_64-none\Lib\asyncio\base_events.py", line 683, in run_forever
  |     self._run_once()
  |   File "C:\Users\hmy01\AppData\Roaming\uv\python\cpython-3.13.6-windows-x86_64-none\Lib\asyncio\base_events.py", line 2050, in _run_once
  |     handle._run()
  |   File "C:\Users\hmy01\AppData\Roaming\uv\python\cpython-3.13.6-windows-x86_64-none\Lib\asyncio\events.py", line 89, in _run
  |     self._context.run(self._callback, *self._args)
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\utils.py", line 259, in run_coro_with_shield
  |     return await coro
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\message.py", line 498, in check_and_run_matcher
  |     if not await _check_matcher(
  | > File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\message.py", line 402, in _check_matcher
  |     if not await Matcher.check_rule(bot, event, state, stack, dependency_cache):
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\matcher\matcher.py", line 405, in check_rule
  |     return event_type == (cls.type or event_type) and await cls.rule(
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\rule.py", line 97, in __call__
  |     with catch({SkippedException: _handle_skipped_exception}):
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\exceptiongroup\_catch.py", line 39, in __exit__
  |     raise unhandled from exc.__cause__
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\rule.py", line 98, in __call__
  |     async with anyio.create_task_group() as tg:
  |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Exception Group Traceback (most recent call last):
    |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\rule.py", line 88, in _run_checker
    |     is_passed = await checker(
    |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 104, in __call__
    |     with catch({SkippedException: _handle_skipped}):
    |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\exceptiongroup\_catch.py", line 39, in __exit__
    |     raise unhandled from exc.__cause__
    |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 109, in __call__
    |     values = await self.solve(**kwargs)
    |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 219, in solve
    |     async with anyio.create_task_group() as tg:
    |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\anyio\_backends\_asyncio.py", line 772, in __aexit__
    |     raise BaseExceptionGroup(
    | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
    +-+---------------- 1 ----------------
      | Traceback (most recent call last):
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\base.py", line 1961, in _exec_single_context
      |     self.dialect.do_execute(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\default.py", line 944, in do_execute
      |     cursor.execute(statement, parameters)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\dialects\sqlite\aiosqlite.py", line 177, in execute
      |     self._adapt_connection._handle_exception(error)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\dialects\sqlite\aiosqlite.py", line 337, in _handle_exception
      |     raise error
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\dialects\sqlite\aiosqlite.py", line 159, in execute
      |     self.await_(_cursor.execute(operation, parameters))
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\util\_concurrency_py3k.py", line 132, in await_only
      |     return current.parent.switch(awaitable)  # type: ignore[no-any-return,attr-defined] # noqa: E501
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\util\_concurrency_py3k.py", line 196, in greenlet_spawn
      |     value = await result
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\cursor.py", line 40, in execute
      |     await self._execute(self._cursor.execute, sql, parameters)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\cursor.py", line 32, in _execute
      |     return await self._conn._execute(fn, *args, **kwargs)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\core.py", line 122, in _execute
      |     return await future
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\core.py", line 105, in run
      |     result = function()
      | sqlite3.IntegrityError: UNIQUE constraint failed: nonebot_plugin_user_user.id
      |
      | The above exception was the direct cause of the following exception:
      |
      | Traceback (most recent call last):
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\utils.py", line 259, in run_coro_with_shield
      |     return await coro
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 216, in _solve_field
      |     value = await self._solve_field(field, params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 199, in _solve_field
      |     value = await param._solve(**params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 291, in _solve
      |     return await dependency_cache[call].wait()
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 167, in wait
      |     raise self._exception
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\utils.py", line 259, in run_coro_with_shield
      |     return await coro
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 216, in _solve_field
      |     value = await self._solve_field(field, params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 199, in _solve_field
      |     value = await param._solve(**params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 291, in _solve
      |     return await dependency_cache[call].wait()
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 167, in wait
      |     raise self._exception
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\utils.py", line 259, in run_coro_with_shield
      |     return await coro
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 216, in _solve_field
      |     value = await self._solve_field(field, params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 199, in _solve_field
      |     value = await param._solve(**params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 291, in _solve
      |     return await dependency_cache[call].wait()
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 167, in wait
      |     raise self._exception
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\utils.py", line 259, in run_coro_with_shield
      |     return await coro
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 216, in _solve_field
      |     value = await self._solve_field(field, params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 199, in _solve_field
      |     value = await param._solve(**params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 291, in _solve
      |     return await dependency_cache[call].wait()
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 167, in wait
      |     raise self._exception
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\utils.py", line 259, in run_coro_with_shield
      |     return await coro
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 216, in _solve_field
      |     value = await self._solve_field(field, params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\dependencies\__init__.py", line 199, in _solve_field
      |     value = await param._solve(**params)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot\internal\params.py", line 310, in _solve
      |     result = await target
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\src\utils\user.py", line 23, in get_user_session
      |     user = await get_user(session)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot_plugin_user\params.py", line 18, in get_user
      |     user = await get_user_depends(session.scope, session.user.id)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\nonebot_plugin_user\utils.py", line 91, in get_user_depends
      |     user = await scoped_session.merge(user)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\ext\asyncio\scoping.py", line 955, in merge
      |     return await self._proxied.merge(instance, load=load, options=options)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\ext\asyncio\session.py", line 789, in merge
      |     return await greenlet_spawn(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\util\_concurrency_py3k.py", line 203, in greenlet_spawn
      |     result = context.switch(value)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\session.py", line 3953, in merge
      |     self._autoflush()
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\session.py", line 3065, in _autoflush
      |     raise e.with_traceback(sys.exc_info()[2])
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\session.py", line 3054, in _autoflush
      |     self.flush()
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\session.py", line 4345, in flush
      |     self._flush(objects)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\session.py", line 4480, in _flush
      |     with util.safe_reraise():
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\util\langhelpers.py", line 224, in __exit__
      |     raise exc_value.with_traceback(exc_tb)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\session.py", line 4441, in _flush
      |     flush_context.execute()
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\unitofwork.py", line 466, in execute
      |     rec.execute(self)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\unitofwork.py", line 642, in execute
      |     util.preloaded.orm_persistence.save_obj(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\persistence.py", line 93, in save_obj
      |     _emit_insert_statements(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\orm\persistence.py", line 1048, in _emit_insert_statements
      |     result = connection.execute(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\base.py", line 1413, in execute
      |     return meth(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\sql\elements.py", line 526, in _execute_on_connection
      |     return connection._execute_clauseelement(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\base.py", line 1635, in _execute_clauseelement
      |     ret = self._execute_context(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\base.py", line 1840, in _execute_context
      |     return self._exec_single_context(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\base.py", line 1980, in _exec_single_context
      |     self._handle_dbapi_exception(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\base.py", line 2349, in _handle_dbapi_exception
      |     raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\base.py", line 1961, in _exec_single_context
      |     self.dialect.do_execute(
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\engine\default.py", line 944, in do_execute
      |     cursor.execute(statement, parameters)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\dialects\sqlite\aiosqlite.py", line 177, in execute
      |     self._adapt_connection._handle_exception(error)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\dialects\sqlite\aiosqlite.py", line 337, in _handle_exception
      |     raise error
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\dialects\sqlite\aiosqlite.py", line 159, in execute
      |     self.await_(_cursor.execute(operation, parameters))
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\util\_concurrency_py3k.py", line 132, in await_only
      |     return current.parent.switch(awaitable)  # type: ignore[no-any-return,attr-defined] # noqa: E501
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\sqlalchemy\util\_concurrency_py3k.py", line 196, in greenlet_spawn
      |     value = await result
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\cursor.py", line 40, in execute
      |     await self._execute(self._cursor.execute, sql, parameters)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\cursor.py", line 32, in _execute
      |     return await self._conn._execute(fn, *args, **kwargs)
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\core.py", line 122, in _execute
      |     return await future
      |   File "C:\Users\hmy01\Works\Working\Bot\CoolQBot\.venv\Lib\site-packages\aiosqlite\core.py", line 105, in run
      |     result = function()
      | sqlalchemy.exc.IntegrityError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
      | (sqlite3.IntegrityError) UNIQUE constraint failed: nonebot_plugin_user_user.id
      | [SQL: INSERT INTO nonebot_plugin_user_user (id, created_at, name, email) VALUES (?, ?, ?, ?)]
      | [parameters: (1, '2025-08-16 04:29:57.000000', 'QQClient-417557420', None)]
      | (Background on this error at: https://sqlalche.me/e/20/gkpj)
      +------------------------------------
```