### PR TITLE
fix: 使用 GitHub 版 Alconna 兼容新版 QQ 适配器

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ override-dependencies = [
 [tool.uv.pip]
 universal = true
 
+[tool.uv.sources]
+nonebot-plugin-alconna = { git = "https://github.com/nonebot/plugin-alconna.git" }
+
 [tool.poe.tasks]
 test = "pytest --cov=src --cov-report xml --junitxml=./junit.xml -n auto"
 bump = "bump-my-version bump"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(HOME_DIR))
 def pytest_configure(config: pytest.Config) -> None:
     config.stash[NONEBOT_INIT_KWARGS] = {
         "alembic_startup_check": False,
-        "superusers": ["nickname"],
+        "superusers": ["nickname", "nickname_qq"],
         "qq_bots": [
             {
                 "id": "123456",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,11 +92,19 @@ async def _default_user(app: App):
     # 添加 user 缓存
     from nonebot_plugin_user.utils import get_user, set_user_email, set_user_name
 
+    # OneBot V11 适配器用户
     await get_user("QQClient", "10")
     await set_user_name("QQClient", "10", "nickname")
     await set_user_email("QQClient", "10", "nickname@example.com")
     await get_user("QQClient", "10000")
     await set_user_name("QQClient", "10000", "nickname10000")
+
+    # QQ 适配器用户
+    await get_user("QQAPI", "10")
+    await set_user_name("QQAPI", "10", "nickname_qq")
+    await set_user_email("QQAPI", "10", "nickname_qq@example.com")
+    await get_user("QQAPI", "10000")
+    await set_user_name("QQAPI", "10000", "nickname10000_qq")
 
     # 添加 uninfo 缓存
     from nonebot_plugin_uninfo import Member, Scene, SceneType, Session, User
@@ -120,6 +128,35 @@ async def _default_user(app: App):
         self_id="123456",
         adapter="OneBot V11",
         scope="QQClient",
+        scene=Scene(
+            id="10000",
+            type=SceneType.GROUP,
+        ),
+        user=User(id="10000", name="nickname10000"),
+        member=Member(
+            user=User(id="10000", name="nickname10000"),
+        ),
+    )
+
+    # QQ 适配器缓存
+    qq_uninfo_cache = INFO_FETCHER_MAPPING["QQ"].session_cache
+    qq_uninfo_cache["group_10000_10"] = Session(
+        self_id="123456",
+        adapter="QQ",
+        scope="QQAPI",
+        scene=Scene(
+            id="10000",
+            type=SceneType.GROUP,
+        ),
+        user=User(id="10", name="nickname"),
+        member=Member(
+            user=User(id="10", name="nickname"),
+        ),
+    )
+    qq_uninfo_cache["group_10000_10000"] = Session(
+        self_id="123456",
+        adapter="QQ",
+        scope="QQAPI",
         scene=Scene(
             id="10000",
             type=SceneType.GROUP,

--- a/tests/fake.py
+++ b/tests/fake.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
     from nonebot.adapters.onebot.v12 import (
         PrivateMessageEvent as PrivateMessageEventV12,
     )
+    from nonebot.adapters.qq.event import (
+        GroupMessageCreateEvent as GroupMessageCreateEventQQ,
+    )
 
 
 def fake_group_message_event_v11(**field) -> "GroupMessageEventV11":
@@ -115,6 +118,40 @@ def fake_private_message_event_v12(**field) -> "PrivateMessageEventV12":
         to_me: bool = False
 
     return FakeEvent(**field)
+
+
+def fake_group_message_event_qq(**field) -> "GroupMessageCreateEventQQ":
+    from nonebot.adapters.qq.event import GroupMessageCreateEvent
+    from nonebot.adapters.qq.models import GroupMemberAuthor
+    from pydantic import create_model
+
+    # 处理 author__xxx 形式的嵌套字段
+    author_defaults: dict = {
+        "id": "10",
+        "bot": False,
+        "member_openid": "10",
+        "username": "test",
+    }
+    flat_fields: dict = {}
+    for key, value in field.items():
+        if key.startswith("author__"):
+            author_defaults[key.removeprefix("author__")] = value
+        else:
+            flat_fields[key] = value
+
+    _Fake = create_model("_Fake", __base__=GroupMessageCreateEvent)
+
+    class FakeEvent(_Fake):
+        id: str = "1"
+        __type__: Literal["GROUP_MESSAGE_CREATE"] = "GROUP_MESSAGE_CREATE"  # type: ignore[assignment]
+        to_me: bool = False
+        author: GroupMemberAuthor = GroupMemberAuthor(**author_defaults)
+        group_id: str = "10000"
+        group_openid: str = "10000"
+        content: str = "test"
+        timestamp: str = "1000000"
+
+    return FakeEvent(**flat_fields)
 
 
 def fake_channel_message_event_v12(**field) -> "ChannelMessageEventV12":

--- a/tests/plugins/llm_quota/test_quota_qq.py
+++ b/tests/plugins/llm_quota/test_quota_qq.py
@@ -21,7 +21,7 @@ async def test_quota_not_configured_qq(app: App):
         bot = ctx.create_bot(
             base=Bot, adapter=adapter, self_id="123456", bot_info=BotInfo(id="123456", token="token", secret="secret")
         )
-        event = fake_group_message_event_qq(content="/quota", group_openid="10000", author__member_openid="10000")
+        event = fake_group_message_event_qq(content="/quota", group_openid="10000", author__member_openid="10")
 
         ctx.receive_event(bot, event)
         ctx.should_call_send(
@@ -38,7 +38,7 @@ async def test_quota_with_config_qq(app: App, respx_mock: MockRouter):
     from src.plugins.llm_quota import quota_cmd
     from src.plugins.llm_quota.data_source import set_group_api_url
 
-    await set_group_api_url("group_10000_10000", "https://ai.example.com/api/quotas")
+    await set_group_api_url("QQAPI_10000", "https://ai.example.com/api/quotas")
 
     mock_data = {
         "buckets": [
@@ -63,7 +63,7 @@ async def test_quota_with_config_qq(app: App, respx_mock: MockRouter):
         bot = ctx.create_bot(
             base=Bot, adapter=adapter, self_id="123456", bot_info=BotInfo(id="123456", token="token", secret="secret")
         )
-        event = fake_group_message_event_qq(content="/quota", group_openid="10000", author__member_openid="10000")
+        event = fake_group_message_event_qq(content="/quota", group_openid="10000", author__member_openid="10")
 
         ctx.receive_event(bot, event)
         ctx.should_call_send(
@@ -102,7 +102,7 @@ async def test_quota_set_by_superuser_qq(app: App):
         )
         ctx.should_finished(quota_cmd)
 
-    api_url = await get_group_api_url("group_10000_10")
+    api_url = await get_group_api_url("QQAPI_10000")
     assert api_url == "https://ai.example.com/api/quotas"
 
 
@@ -111,7 +111,7 @@ async def test_quota_remove_by_superuser_qq(app: App):
     from src.plugins.llm_quota import quota_cmd
     from src.plugins.llm_quota.data_source import get_group_api_url, set_group_api_url
 
-    await set_group_api_url("group_10000_10", "https://ai.example.com/api/quotas")
+    await set_group_api_url("QQAPI_10000", "https://ai.example.com/api/quotas")
 
     async with app.test_matcher() as ctx:
         adapter = get_adapter(Adapter)
@@ -128,7 +128,7 @@ async def test_quota_remove_by_superuser_qq(app: App):
         ctx.should_call_send(event, "已删除额度查询 API 配置", True, at_sender=True)
         ctx.should_finished(quota_cmd)
 
-    api_url = await get_group_api_url("group_10000_10")
+    api_url = await get_group_api_url("QQAPI_10000")
     assert api_url is None
 
 

--- a/tests/plugins/llm_quota/test_quota_qq.py
+++ b/tests/plugins/llm_quota/test_quota_qq.py
@@ -1,0 +1,152 @@
+"""测试大模型额度查询命令 (QQ 适配器)"""
+
+import httpx
+import pytest
+import respx
+from nonebot import get_adapter
+from nonebot.adapters.qq import Adapter, Bot
+from nonebot.adapters.qq.config import BotInfo
+from nonebug import App
+from respx import MockRouter
+
+from tests.fake import fake_group_message_event_qq
+
+
+@pytest.mark.asyncio
+async def test_quota_not_configured_qq(app: App):
+    from src.plugins.llm_quota import quota_cmd
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(
+            base=Bot, adapter=adapter, self_id="123456", bot_info=BotInfo(id="123456", token="token", secret="secret")
+        )
+        event = fake_group_message_event_qq(content="/quota", group_openid="10000", author__member_openid="10000")
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(
+            event,
+            "当前群组未配置额度查询 API，请管理员使用 /quota set 命令配置",
+            True,
+            at_sender=True,
+        )
+        ctx.should_finished(quota_cmd)
+
+
+@respx.mock(assert_all_called=True)
+async def test_quota_with_config_qq(app: App, respx_mock: MockRouter):
+    from src.plugins.llm_quota import quota_cmd
+    from src.plugins.llm_quota.data_source import set_group_api_url
+
+    await set_group_api_url("group_10000_10000", "https://ai.example.com/api/quotas")
+
+    mock_data = {
+        "buckets": [
+            {
+                "name": "deepseek",
+                "current": 4820000000,
+                "capacity": 6280000000,
+                "rate": "$0.000000001/month",
+                "models": ["deepseek/*"],
+                "paused": False,
+                "last_updated": "2026-05-13T03:09:33.5934363Z",
+            }
+        ]
+    }
+
+    quotas_mock = respx_mock.get("https://ai.example.com/api/quotas").mock(
+        return_value=httpx.Response(200, json=mock_data)
+    )
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(
+            base=Bot, adapter=adapter, self_id="123456", bot_info=BotInfo(id="123456", token="token", secret="secret")
+        )
+        event = fake_group_message_event_qq(content="/quota", group_openid="10000", author__member_openid="10000")
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(
+            event,
+            "大模型剩余额度：\n  deepseek: 4.82 元",
+            True,
+            at_sender=True,
+        )
+        ctx.should_finished(quota_cmd)
+
+    assert quotas_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_quota_set_by_superuser_qq(app: App):
+    from src.plugins.llm_quota import quota_cmd
+    from src.plugins.llm_quota.data_source import get_group_api_url
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(
+            base=Bot, adapter=adapter, self_id="123456", bot_info=BotInfo(id="123456", token="token", secret="secret")
+        )
+        event = fake_group_message_event_qq(
+            content="/quota set https://ai.example.com/api/quotas",
+            group_openid="10000",
+            author__member_openid="10",
+        )
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(
+            event,
+            "已设置额度查询 API 地址：https://ai.example.com/api/quotas",
+            True,
+            at_sender=True,
+        )
+        ctx.should_finished(quota_cmd)
+
+    api_url = await get_group_api_url("group_10000_10")
+    assert api_url == "https://ai.example.com/api/quotas"
+
+
+@pytest.mark.asyncio
+async def test_quota_remove_by_superuser_qq(app: App):
+    from src.plugins.llm_quota import quota_cmd
+    from src.plugins.llm_quota.data_source import get_group_api_url, set_group_api_url
+
+    await set_group_api_url("group_10000_10", "https://ai.example.com/api/quotas")
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(
+            base=Bot, adapter=adapter, self_id="123456", bot_info=BotInfo(id="123456", token="token", secret="secret")
+        )
+        event = fake_group_message_event_qq(
+            content="/quota remove",
+            group_openid="10000",
+            author__member_openid="10",
+        )
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "已删除额度查询 API 配置", True, at_sender=True)
+        ctx.should_finished(quota_cmd)
+
+    api_url = await get_group_api_url("group_10000_10")
+    assert api_url is None
+
+
+@pytest.mark.asyncio
+async def test_quota_remove_not_configured_qq(app: App):
+    from src.plugins.llm_quota import quota_cmd
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(
+            base=Bot, adapter=adapter, self_id="123456", bot_info=BotInfo(id="123456", token="token", secret="secret")
+        )
+        event = fake_group_message_event_qq(
+            content="/quota remove",
+            group_openid="10000",
+            author__member_openid="10",
+        )
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "当前群组未配置额度查询 API", True, at_sender=True)
+        ctx.should_finished(quota_cmd)

--- a/uv.lock
+++ b/uv.lock
@@ -634,7 +634,7 @@ requires-dist = [
     { name = "nonebot-adapter-telegram", specifier = ">=0.1.0b20" },
     { name = "nonebot-bison", specifier = "==0.9.14" },
     { name = "nonebot-plugin-abs", specifier = "==1.1.0" },
-    { name = "nonebot-plugin-alconna", specifier = ">=0.62.0" },
+    { name = "nonebot-plugin-alconna", git = "https://github.com/nonebot/plugin-alconna.git" },
     { name = "nonebot-plugin-alisten", specifier = ">=0.4.3" },
     { name = "nonebot-plugin-apscheduler", specifier = ">=0.5.0" },
     { name = "nonebot-plugin-datastore", specifier = ">=1.3.1" },
@@ -1804,7 +1804,7 @@ wheels = [
 [[package]]
 name = "nonebot-plugin-alconna"
 version = "0.62.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/nonebot/plugin-alconna.git#e0f2a3dc81906cf2147b94595b7b5f5145235821" }
 dependencies = [
     { name = "arclet-alconna" },
     { name = "arclet-alconna-tools" },
@@ -1813,10 +1813,6 @@ dependencies = [
     { name = "nonebot-plugin-waiter" },
     { name = "nonebot2" },
     { name = "tarina" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/18/478f1915898399a96506398b079ddef3303b12a2c2888859ad9d4a0bc739/nonebot_plugin_alconna-0.62.0.tar.gz", hash = "sha256:24fc3bc0cff09febb22bfadb3146c147c092c4156444b274ac1b8d2cd77f1a9d", size = 162640, upload-time = "2026-04-07T02:10:02.765Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/e9/3d4bdb54950da7c8dff3264b58c0c96a9a2dcb7535c89dec28fcf6bc5f9c/nonebot_plugin_alconna-0.62.0-py3-none-any.whl", hash = "sha256:a8b644f05f0a9e57c307e26296ae1bc58a3f91ef24733d7c0f00a06bd2036b8c", size = 225305, upload-time = "2026-04-07T02:10:01.145Z" },
 ]
 
 [[package]]
@@ -3195,30 +3191,30 @@ wheels = [
 
 [[package]]
 name = "tarina"
-version = "0.7.4"
+version = "0.7.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/13/d6bf335c5be4183a602af81bcdab467c0bb1bd238ae73f79375d04610b1b/tarina-0.7.4.tar.gz", hash = "sha256:71f6aecb9a71b619b4cf4970e5357a4bf8aa4f05ac92d7078e84a4262e3b50a8", size = 128609, upload-time = "2026-05-12T01:43:12.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/a8/213153fea451175642173d4fad95d8c347b2510a5c7a3a6c74489547fed8/tarina-0.7.5.tar.gz", hash = "sha256:581a1a7c0f60a54aa2b93a4989bbb333fb9d26ffda96b0addf9309b736a7c831", size = 128699, upload-time = "2026-05-18T09:14:33.787Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/b7/c935cced05aa618a836400086306b9ee1ee73edcad5b0488d47ca7085f01/tarina-0.7.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c6cb3591167fa2dcf30db6b861b29b8159857ac53e0de087e39dddf4d09167ae", size = 98602, upload-time = "2026-05-12T01:42:36.235Z" },
-    { url = "https://files.pythonhosted.org/packages/59/93/fe6137e28da0bb10d06143daa4e9c0b9a50e79490b4b4b3ed2ed2aa5b9ab/tarina-0.7.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1f95a252f267ac44fdf1d55cef579eec14b69cf0114472c89d3bc418fc9f643", size = 376029, upload-time = "2026-05-12T01:42:37.197Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c0/6dc5e9397599c740c4cdded0c4c9899d5d8d6178d62536c1273494d12cfc/tarina-0.7.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23943c58d81c225b708245d35187d87522dace47ecfcadb7aede60a6b4c59454", size = 348386, upload-time = "2026-05-12T01:42:38.181Z" },
-    { url = "https://files.pythonhosted.org/packages/76/42/7267a2ae425e7b6677b63f0221d6d7ba1bc55d836be6b295acbb85539ec3/tarina-0.7.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b40f50496a2cb0fc9d25626645bffd6ec156a0a39a3251947f3d4fb0ae5c071", size = 392113, upload-time = "2026-05-12T01:42:39.089Z" },
-    { url = "https://files.pythonhosted.org/packages/17/a1/0cb0041c31fa4b54e384fe1ecfb7746b3945c415f1b86954db0bf48adde9/tarina-0.7.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8f3a79aef061b782395ed5aabdcb2f5f3db8e66d7ac19f681a097298055913da", size = 401414, upload-time = "2026-05-12T01:42:40.08Z" },
-    { url = "https://files.pythonhosted.org/packages/47/70/f6789ab5834b334e976c58d9a2286af3e3cd21fb695165edf1e4f995ce21/tarina-0.7.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5c58eb04ce3089ca4338ac9cb2bd6fe18f093ede44baf55406202412ef820e89", size = 378106, upload-time = "2026-05-12T01:42:41.167Z" },
-    { url = "https://files.pythonhosted.org/packages/22/46/b3a6ba434f60842d41f61c3662718c049084eb5f00cccca3155eb313fce5/tarina-0.7.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3d01ffc45ad7c47d3c507c73c2f1819fe2a5d5018ec01684be54112497eaea0f", size = 348186, upload-time = "2026-05-12T01:42:42.513Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/ba/d127bcba09d5763da054f940afe0c89291f3ffdc5c43f40e7cc8d6f3c374/tarina-0.7.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:10800690f2ebd3a600a54b85b39c9dd31d89f5e62f2b0bb2255de5e75f482ebe", size = 370950, upload-time = "2026-05-12T01:42:43.579Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a2/807cd3fe0dd41b3438d0369279ec7c3063489b8b35b65634e59a125d8233/tarina-0.7.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:58559ad568fb21f3a6b01e727606f8e4ceb345723abeb496237e51a50cb2b1b8", size = 355412, upload-time = "2026-05-12T01:42:44.959Z" },
-    { url = "https://files.pythonhosted.org/packages/86/40/d10cf90baa98a65c144c31eae321f3af5d2ea0206ee817a2f3894eb26869/tarina-0.7.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0850f870f3071ff964cf7b05212562136314e1900b604cb47a7d9441697e0f9a", size = 386943, upload-time = "2026-05-12T01:42:46.122Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/5c/0ea6c21aa7710505af82bef4650933e7d3009ab3577ebe5ed6f026f3f5e3/tarina-0.7.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:bc74c5124785c2a7e7f73875894730046c483c39dab8fe17fc97bca76db8ef56", size = 347171, upload-time = "2026-05-12T01:42:47.224Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/ed/8daca96d8c3fc6ee2e3ad4143a7f48d2d72fbc32d22625fe0d1d25772945/tarina-0.7.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:43e2d9bc9f972039f90dd7abe56ca3ebb9b2b9151f682d03f553af29e6708361", size = 393632, upload-time = "2026-05-12T01:42:48.296Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/e2/a038ada40ecc29447cc0485bb76ee4ef9f7b9442db8ec090a3ef3fadf3e6/tarina-0.7.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9779887289bf3f5db2fb5bb55b1e8c3808c217d26cde4a2561554e4aa395fd6d", size = 381517, upload-time = "2026-05-12T01:42:49.343Z" },
-    { url = "https://files.pythonhosted.org/packages/73/50/4b26bdb5c9d384b03ada99b261cebf28d72f8d3d5bfbe4a244cc2245dcce/tarina-0.7.4-cp314-cp314-win32.whl", hash = "sha256:200f40542df9cfdca57265a48617ec3653de96adf0aca9c97b4e3bd032012ce2", size = 93690, upload-time = "2026-05-12T01:42:50.3Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/74/7422b364449209b8c7501d8f98de352498bcf654a1129bc7a283504355a4/tarina-0.7.4-cp314-cp314-win_amd64.whl", hash = "sha256:d141be858c8c0af65e3f437486f8434f5ed164dc927d9030896faddc3d13df02", size = 99749, upload-time = "2026-05-12T01:42:51.282Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/af/e9082cdedea10e6bd0aed51da3d9770881a8567c072c9b1241921d77deff/tarina-0.7.4-cp314-cp314-win_arm64.whl", hash = "sha256:ac4fcecf38d31ebfd54ac51dca3bd88a9d21a2b99082e796d14e601dafcd7bbe", size = 92370, upload-time = "2026-05-12T01:42:52.201Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/eb/2d545e7e6243996b1b607a951efad58702469ca49e418ec130bc2527998c/tarina-0.7.4-py3-none-any.whl", hash = "sha256:000f760baad984177dc7e0d2c48077ef7743d014544d9f30aec2930ff8ecca4a", size = 48542, upload-time = "2026-05-12T01:43:11.902Z" },
+    { url = "https://files.pythonhosted.org/packages/56/95/e8828a9086ef14b1fafc36f794e4142baeeddb0e8b44bc7d8b4a6c9389f8/tarina-0.7.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:74f8668da4eebbcd49910f8a88546a0b86389c948598e01570bea992e8a8af30", size = 98643, upload-time = "2026-05-18T09:13:48.956Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/12/0e1ec7fd19533105fb0429fb4aae65ad90e14623ee4bd4221f7efd47ba8d/tarina-0.7.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:895301d752708909ec06d266633c212dc43a08a7ce699b6506b48ee1efb9d0ec", size = 376071, upload-time = "2026-05-18T09:13:50.147Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d5/8bca7977b6bf45a477f68ce2f5792040a2329b291ad96bb4641f749b1f65/tarina-0.7.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:189079fb636c42ad9dfac37ee71b1b867f4993bc5d95ee6da441a2150e410248", size = 348429, upload-time = "2026-05-18T09:13:51.612Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/da/817c0e37179049ccca03b8f8799ecc6b3bf83a612eb9854546b8dcce0d99/tarina-0.7.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c138371b5452e11f5b26d0a2a1fd1fb85ebcbd3d3546b5b8bd6170aefa298eee", size = 392156, upload-time = "2026-05-18T09:13:53.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e7/1e9b21467bd0d0f18d0c0e5a7f2f0775e67e13b0366ed08ec6e84479932b/tarina-0.7.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:514c555943b0fc955e4ab7705540604d08838cd1e6197736b871dd8943ee3a1d", size = 401455, upload-time = "2026-05-18T09:13:54.764Z" },
+    { url = "https://files.pythonhosted.org/packages/59/14/74510c9f5fa9a35859e818bc2e9451f0592d44c00db8b70e54e4006faf8f/tarina-0.7.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89fe43399590c244aa3971446690ca31a7107e3cfce983e47049837ce45111f6", size = 378148, upload-time = "2026-05-18T09:13:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/35/5479d9f539f863617c6161ec2a4d70914331ab4ac3f52a404bc0332de969/tarina-0.7.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c5fc1861f42fb36869ae5aca823a29ccf46f258d40335edfe53a5c406daacaf7", size = 348227, upload-time = "2026-05-18T09:13:57.909Z" },
+    { url = "https://files.pythonhosted.org/packages/04/45/0e294320dde4c04901c821d6a92d097330478b23ceb4c579f07a0e2a458f/tarina-0.7.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c1fd975e497465ca28f2214541ca2fd2e7d4104bc6827d75ff94756f383c4e5c", size = 370993, upload-time = "2026-05-18T09:13:59.165Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/1d/001f8143c91aedb92ec117957f542422a823109a49a0b44b2076edca9133/tarina-0.7.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7e7ceae88d968cc86d4d8069eb8c3c335a3af1c0bfd4d5b0c731da02f44df739", size = 355456, upload-time = "2026-05-18T09:14:00.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/12/c6c868dcaa20dd06ae5f049e251cccea2ff6e172612a348f9e52d3b1768f/tarina-0.7.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6384e8f994d821c88bed510f178ddb192f9450d170e81f4b2046a328622cf5c1", size = 386985, upload-time = "2026-05-18T09:14:02.261Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a6/1198498ba428f02619a30638740eba90d0a14e4a5e09efb4e74478383147/tarina-0.7.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:ae0c04f982ec223557ff01a6fab9b734fcc472b86b00ed38c795730fe5b129d8", size = 347215, upload-time = "2026-05-18T09:14:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/85/3f/2dc10559844cd5b2f1e5b831fbc623d868abc4474f2a7d285527df27da35/tarina-0.7.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:45d8f6320bf2d40c888abb6a9bc435f35e6e8f667d75f65ea57aafd1ac76a42b", size = 393674, upload-time = "2026-05-18T09:14:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ae/6fe77051e7ea4a41831d15b64e764b7f257c24f2979d50ae81bf6f9de5eb/tarina-0.7.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4590697a3a4f9b97d214c2a7de3af370fdf12cad729ba800ef4edbad9467d0a6", size = 381559, upload-time = "2026-05-18T09:14:06.871Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/b2/265f0fec032821934989a3f6d22994d5271a429fa01c2eb972a09c806517/tarina-0.7.5-cp314-cp314-win32.whl", hash = "sha256:23d8e301d599b9b62fbc2663cffb94a4a93cad822b3e1526dcd7428169f87151", size = 93739, upload-time = "2026-05-18T09:14:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/66/5e/656d52aa389f9e9c97385e3073860b2c177aae3261ff607a7b0d1113b19e/tarina-0.7.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa4344d0172c217ce11fa3318829faa90e09e28a38e3838705e085e200ae2116", size = 99797, upload-time = "2026-05-18T09:14:09.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/25/6ef0affe179e09358ca685e2616bdfebf2ca88f5bef1f9e2ca6786eff2bd/tarina-0.7.5-cp314-cp314-win_arm64.whl", hash = "sha256:714d16892d6258cb7e1dddf19ffe954f62e899e9857bfc1a2a4016c24c7eafbe", size = 92417, upload-time = "2026-05-18T09:14:10.15Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/31/8de99c767e77174c2e32ebce81110b2daff5949943835a956c1fc8f36bcd/tarina-0.7.5-py3-none-any.whl", hash = "sha256:f8d25cd4953f5613fac478cd9b5af5d598542033f385a45fe5e88e8ddf566af0", size = 48582, upload-time = "2026-05-18T09:14:32.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 变更内容

- 将 `nonebot-plugin-alconna` 切换为 GitHub 源，使用上游最新代码以兼容新版 QQ 适配器。
- 更新 `uv.lock`，同步 GitHub 源的 Alconna 版本及相关依赖解析结果。
- 补充 QQ 适配器下 `/quota` 命令的测试覆盖。
- 在测试环境中补齐 QQ 适配器用户、超级用户和 uninfo session 缓存。
- 添加 QQ 群消息事件构造工具，便于后续覆盖 QQ 适配器命令测试。

## 背景

当前发布版 Alconna 尚未支持最新的 QQ 适配器，导致基于 QQ 适配器的命令测试无法正常工作。本 PR 先直接使用 GitHub 上的 Alconna 最新代码，等待上游正式发布后可再切回 PyPI 版本。

## 测试覆盖

新增的 QQ 适配器测试用于防止后续再次遇到类似兼容问题，覆盖：

- 未配置额度 API 时的 `/quota` 查询提示。
- 已配置额度 API 时的额度查询结果。
- 超级用户执行 `/quota set`。
- 超级用户执行 `/quota remove`。
- 未配置时执行 `/quota remove`。

## 验证

- `uv run pytest tests\plugins\llm_quota\test_quota_qq.py -q`
- `uv run pytest tests\plugins\llm_quota -q`