### PR TITLE
feat(llm): 支持按模型查询额度

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ### Added
 
-- 添加大模型对话插件 (llm)，支持 Chat Completions、Responses 与 Anthropic Messages 三种 API 格式、全局和模型级服务地址配置、响应耗时与 token 用量尾注、会话亲和请求头，以及天气和节假日工具调用
+- 添加大模型对话插件 (llm)，支持 Chat Completions、Responses 与 Anthropic Messages 三种 API 格式、全局和模型级服务地址配置、响应耗时与 token 用量尾注、会话亲和请求头、Aperture 与 DeepSeek 模型额度查询，以及天气和节假日工具调用
 
 ## [0.28.0] - 2026-07-24
 

--- a/src/plugins/llm/README.md
+++ b/src/plugins/llm/README.md
@@ -123,7 +123,6 @@ LLM__MODELS='
     "base_url": "https://ai.example.com/v1",
     "quota": {
       "provider": "aperture",
-      "api_url": "https://ai.example.com/api/quotas",
       "bucket": "deepseek"
     }
   },
@@ -175,13 +174,14 @@ LLM__TTS_MODEL=default
 
 DeepSeek 字段与鉴权方式以[官方余额接口文档](https://api-docs.deepseek.com/zh-cn/api/get-user-balance)为准。
 
-| Provider   | 必填配置  | 说明                                                                |
-| ---------- | --------- | ------------------------------------------------------------------- |
-| `deepseek` | 无        | 请求 DeepSeek 官方 `/user/balance`；默认复用模型 `api_key`          |
-| `aperture` | `api_url` | 请求 Tailscale Aperture `/api/quotas`；可用 `bucket` 筛选单个额度桶 |
+| Provider   | 追加路径        | 说明                                                           |
+| ---------- | --------------- | -------------------------------------------------------------- |
+| `deepseek` | `/user/balance` | 请求 DeepSeek 官方余额接口；默认复用模型 `api_key`             |
+| `aperture` | `/api/quotas`   | 请求 Tailscale Aperture 额度接口；可用 `bucket` 筛选单个额度桶 |
 
-两种 provider 都可单独设置 `api_key`、`proxy` 与 `timeout`。DeepSeek 的 `api_url` 也可以覆盖，
-用于兼容代理或后续不同的服务地址。
+未设置 `quota.api_url` 时，插件优先使用 `LLM__BASE_URL` 并追加上表路径；全局地址也为空时，
+再使用模型解析后的服务地址。`quota.api_url` 可填写完整地址以覆盖这一行为。两种 provider 还可单独设置
+`api_key`、`proxy` 与 `timeout`。
 
 ## 内置工具
 

--- a/src/plugins/llm/README.md
+++ b/src/plugins/llm/README.md
@@ -23,6 +23,7 @@
 - 在回复末尾显示整轮耗时、实际模型和 token 用量，工具调用产生的多次请求会累计统计
 - Markdown 转图片
 - TTS 语音回复（GPT-SoVITS）
+- 按模型查询剩余额度，支持 Tailscale Aperture 与 DeepSeek 官方余额接口
 
 ## 请求标识
 
@@ -44,6 +45,7 @@
 | `/llm model --set <模型名>`    | -     | 设置群组默认模型      | 所有人 |
 | `/llm tts --list`              | -     | 查看可用 TTS 模型列表 | 所有人 |
 | `/llm tts --set <模型名>`      | -     | 设置群组默认 TTS 模型 | 所有人 |
+| `/llm quota [模型名]`          | -     | 查询模型剩余额度      | 所有人 |
 
 ## 使用方法
 
@@ -61,6 +63,8 @@
 /llm model --list                # 查看有哪些模型
 /llm 讲个笑话 --model claude     # 本次使用 claude
 /llm model --set claude          # 之后本群默认使用 claude
+/llm quota                       # 查询本群当前模型的剩余额度
+/llm quota deepseek              # 查询指定模型的剩余额度
 ```
 
 ### 多轮对话
@@ -107,7 +111,21 @@ LLM__MODELS='
   {
     "name": "deepseek",
     "provider": "chat",
-    "model": "deepseek-chat"
+    "model": "deepseek-chat",
+    "quota": {
+      "provider": "deepseek"
+    }
+  },
+  {
+    "name": "deepseek-aperture",
+    "provider": "chat",
+    "model": "deepseek-chat",
+    "base_url": "https://ai.example.com/v1",
+    "quota": {
+      "provider": "aperture",
+      "api_url": "https://ai.example.com/api/quotas",
+      "bucket": "deepseek"
+    }
   },
   {
     "name": "gpt",
@@ -149,6 +167,21 @@ LLM__TTS_MODEL=default
 | `temperature` | 采样温度                                                |
 | `timeout`     | 非流式请求超时时间（秒）                                |
 | `extra_body`  | 附加到请求体的额外字段，用于传各服务商特有参数          |
+| `quota`       | 该模型的额度查询配置，留空时不支持 `/llm quota`         |
+
+### 额度查询配置
+
+`quota.provider` 决定额度接口的请求和响应格式，目前支持：
+
+DeepSeek 字段与鉴权方式以[官方余额接口文档](https://api-docs.deepseek.com/zh-cn/api/get-user-balance)为准。
+
+| Provider   | 必填配置  | 说明                                                                |
+| ---------- | --------- | ------------------------------------------------------------------- |
+| `deepseek` | 无        | 请求 DeepSeek 官方 `/user/balance`；默认复用模型 `api_key`          |
+| `aperture` | `api_url` | 请求 Tailscale Aperture `/api/quotas`；可用 `bucket` 筛选单个额度桶 |
+
+两种 provider 都可单独设置 `api_key`、`proxy` 与 `timeout`。DeepSeek 的 `api_url` 也可以覆盖，
+用于兼容代理或后续不同的服务地址。
 
 ## 内置工具
 

--- a/src/plugins/llm/__init__.py
+++ b/src/plugins/llm/__init__.py
@@ -2,6 +2,7 @@
 
 支持 OpenAI Chat Completions / OpenAI Responses / Anthropic Messages 三种
 API 格式，提供多轮对话、推理内容展示、Markdown 转图片与 TTS 语音回复。
+额度查询按模型选择独立 provider，目前支持 Aperture 与 DeepSeek。
 """
 
 from nonebot import require
@@ -40,6 +41,7 @@ from .config import plugin_config
 from .data_source import get_model_name, get_tts_model, set_model_name, set_tts_model
 from .handler import LLMHandler
 from .providers import ProviderError
+from .quota import QuotaError, get_quota
 from .schemas import ImageContent
 from .tts import TTSError, get_tts_models
 
@@ -69,6 +71,11 @@ llm_cmd = on_alconna(
             Option("-l|--list", help_text="查看 TTS 模型列表"),
             Option("--set", Args["model#模型名称", str], help_text="设置群组默认 TTS 模型"),
             help_text="TTS 模型相关设置",
+        ),
+        Subcommand(
+            "quota",
+            Args["model?#模型名称", str],
+            help_text="查询大模型剩余额度",
         ),
         meta=CommandMeta(
             description=__plugin_meta__.description,
@@ -156,6 +163,23 @@ async def llm_tts_set_handle(
 
     await set_tts_model(user.session_id, model.result)
     await llm_cmd.finish(f"已设置群组默认 TTS 模型为：{model.result}", at_sender=True)
+
+
+@llm_cmd.assign("quota")
+async def llm_quota_handle(user: UserSession, model: Query[str] = Query("quota.model")):
+    names = plugin_config.get_model_names()
+    if not names:
+        await llm_cmd.finish("未配置任何模型，请先在 .env 中配置 LLM__MODELS")
+
+    name = model.result if model.available else await get_model_name(user.session_id)
+    if name not in names:
+        await llm_cmd.finish(f"未启用的模型：{name}，可用：{'、'.join(names)}", at_sender=True)
+
+    try:
+        result = await get_quota(plugin_config.resolve(name))
+    except QuotaError as e:
+        await llm_cmd.finish(str(e), at_sender=True)
+    await llm_cmd.finish(result, at_sender=True)
 
 
 @llm_cmd.handle()

--- a/src/plugins/llm/__init__.py
+++ b/src/plugins/llm/__init__.py
@@ -176,7 +176,7 @@ async def llm_quota_handle(user: UserSession, model: Query[str] = Query("quota.m
         await llm_cmd.finish(f"未启用的模型：{name}，可用：{'、'.join(names)}", at_sender=True)
 
     try:
-        result = await get_quota(plugin_config.resolve(name), plugin_config.base_url)
+        result = await get_quota(plugin_config.resolve(name))
     except QuotaError as e:
         await llm_cmd.finish(str(e), at_sender=True)
     await llm_cmd.finish(result, at_sender=True)

--- a/src/plugins/llm/__init__.py
+++ b/src/plugins/llm/__init__.py
@@ -176,7 +176,7 @@ async def llm_quota_handle(user: UserSession, model: Query[str] = Query("quota.m
         await llm_cmd.finish(f"未启用的模型：{name}，可用：{'、'.join(names)}", at_sender=True)
 
     try:
-        result = await get_quota(plugin_config.resolve(name))
+        result = await get_quota(plugin_config.resolve(name), plugin_config.base_url)
     except QuotaError as e:
         await llm_cmd.finish(str(e), at_sender=True)
     await llm_cmd.finish(result, at_sender=True)

--- a/src/plugins/llm/config.py
+++ b/src/plugins/llm/config.py
@@ -31,6 +31,8 @@ DEEPSEEK_QUOTA_API_URL = "https://api.deepseek.com/user/balance"
 class BaseQuotaConfig(BaseModel):
     """额度查询的共用配置"""
 
+    api_url: str = ""
+    """完整的额度接口地址；留空时回退到全局 LLM 服务地址"""
     api_key: str = ""
     """额度接口密钥；留空时由具体 provider 决定是否复用模型密钥"""
     proxy: str | None = None
@@ -43,8 +45,6 @@ class ApertureQuotaConfig(BaseQuotaConfig):
     """Tailscale Aperture 额度接口配置"""
 
     provider: Literal["aperture"]
-    api_url: str
-    """完整的 Aperture `/api/quotas` 地址"""
     bucket: str = ""
     """仅显示指定额度桶；留空时显示接口返回的全部额度桶"""
 
@@ -53,8 +53,6 @@ class DeepSeekQuotaConfig(BaseQuotaConfig):
     """DeepSeek 官方余额接口配置"""
 
     provider: Literal["deepseek"]
-    api_url: str = DEEPSEEK_QUOTA_API_URL
-    """完整的余额查询地址"""
 
 
 QuotaConfig = Annotated[ApertureQuotaConfig | DeepSeekQuotaConfig, Field(discriminator="provider")]

--- a/src/plugins/llm/config.py
+++ b/src/plugins/llm/config.py
@@ -9,7 +9,7 @@ LLM__MODELS='[{"name":"model-a","provider":"chat"}]'
 ```
 """
 
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from nonebot import get_plugin_config
 from pydantic import BaseModel, Field, model_validator
@@ -23,6 +23,42 @@ DEFAULT_BASE_URLS: dict[str, str] = {
     "anthropic": "https://api.anthropic.com",
 }
 """各格式的默认服务地址"""
+
+DEEPSEEK_QUOTA_API_URL = "https://api.deepseek.com/user/balance"
+"""DeepSeek 官方余额查询地址"""
+
+
+class BaseQuotaConfig(BaseModel):
+    """额度查询的共用配置"""
+
+    api_key: str = ""
+    """额度接口密钥；留空时由具体 provider 决定是否复用模型密钥"""
+    proxy: str | None = None
+    """额度查询代理地址；留空时复用模型代理"""
+    timeout: int = 10
+    """额度查询超时时间（秒）"""
+
+
+class ApertureQuotaConfig(BaseQuotaConfig):
+    """Tailscale Aperture 额度接口配置"""
+
+    provider: Literal["aperture"]
+    api_url: str
+    """完整的 Aperture `/api/quotas` 地址"""
+    bucket: str = ""
+    """仅显示指定额度桶；留空时显示接口返回的全部额度桶"""
+
+
+class DeepSeekQuotaConfig(BaseQuotaConfig):
+    """DeepSeek 官方余额接口配置"""
+
+    provider: Literal["deepseek"]
+    api_url: str = DEEPSEEK_QUOTA_API_URL
+    """完整的余额查询地址"""
+
+
+QuotaConfig = Annotated[ApertureQuotaConfig | DeepSeekQuotaConfig, Field(discriminator="provider")]
+"""单个模型的额度查询配置"""
 
 
 class ModelConfig(BaseModel):
@@ -52,6 +88,8 @@ class ModelConfig(BaseModel):
     """非流式请求的超时时间（秒）"""
     extra_body: dict[str, Any] = Field(default_factory=dict)
     """附加到请求体的额外字段，用于传递各服务商的特有参数"""
+    quota: QuotaConfig | None = None
+    """该模型的额度查询配置，留空时不支持额度查询"""
 
     @model_validator(mode="after")
     def fill_defaults(self) -> "ModelConfig":

--- a/src/plugins/llm/quota.py
+++ b/src/plugins/llm/quota.py
@@ -1,0 +1,214 @@
+"""按模型配置查询大模型剩余额度"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import TYPE_CHECKING, Literal
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from .providers.base import USER_AGENT
+
+if TYPE_CHECKING:
+    from .config import ApertureQuotaConfig, BaseQuotaConfig, DeepSeekQuotaConfig, ModelConfig
+
+
+class QuotaError(Exception):
+    """额度查询失败"""
+
+
+@dataclass
+class QuotaItem:
+    """统一后的单项额度信息"""
+
+    name: str
+    amount: Decimal
+    currency: str
+    details: list[tuple[str, Decimal]] = field(default_factory=list)
+
+
+@dataclass
+class QuotaResult:
+    """统一后的额度查询结果"""
+
+    items: list[QuotaItem]
+    available: bool | None = None
+
+
+class ApertureBucket(BaseModel):
+    """Aperture 额度桶响应中的必要字段"""
+
+    name: str
+    current: Decimal
+
+
+class ApertureResponse(BaseModel):
+    """Aperture 额度响应"""
+
+    buckets: list[ApertureBucket]
+
+
+class DeepSeekBalance(BaseModel):
+    """DeepSeek 单币种余额"""
+
+    currency: Literal["CNY", "USD"]
+    total_balance: Decimal
+    granted_balance: Decimal
+    topped_up_balance: Decimal
+
+
+class DeepSeekResponse(BaseModel):
+    """DeepSeek 余额响应"""
+
+    is_available: bool
+    balance_infos: list[DeepSeekBalance]
+
+
+class QuotaProvider(ABC):
+    """额度查询 provider 基类"""
+
+    def __init__(self, config: BaseQuotaConfig, model: ModelConfig) -> None:
+        self.config = config
+        self.model = model
+
+    @property
+    @abstractmethod
+    def api_url(self) -> str:
+        """完整的额度查询地址"""
+
+    def build_headers(self) -> dict[str, str]:
+        """构造请求头"""
+        return {"User-Agent": USER_AGENT}
+
+    @abstractmethod
+    def parse_response(self, data: object) -> QuotaResult:
+        """解析服务商响应"""
+
+    async def query(self) -> QuotaResult:
+        """请求并解析额度信息"""
+        proxy = self.config.proxy if self.config.proxy is not None else self.model.proxy
+        try:
+            async with httpx.AsyncClient(proxy=proxy) as client:
+                response = await client.get(
+                    self.api_url,
+                    headers=self.build_headers(),
+                    timeout=self.config.timeout,
+                )
+                response.raise_for_status()
+                return self.parse_response(response.json())
+        except httpx.TimeoutException as e:
+            raise QuotaError("额度查询超时，请稍后再试") from e
+        except (httpx.HTTPError, ValidationError, ValueError) as e:
+            raise QuotaError("获取额度信息失败，请稍后再试") from e
+
+
+class ApertureQuotaProvider(QuotaProvider):
+    """Tailscale Aperture 额度查询"""
+
+    config: ApertureQuotaConfig
+
+    @property
+    def api_url(self) -> str:
+        return self.config.api_url
+
+    def build_headers(self) -> dict[str, str]:
+        headers = super().build_headers()
+        if self.config.api_key:
+            headers["Authorization"] = f"Bearer {self.config.api_key}"
+        return headers
+
+    def parse_response(self, data: object) -> QuotaResult:
+        response = ApertureResponse.model_validate(data)
+        buckets = response.buckets
+        if self.config.bucket:
+            buckets = [bucket for bucket in buckets if bucket.name == self.config.bucket]
+        return QuotaResult(
+            items=[
+                QuotaItem(
+                    name=bucket.name,
+                    amount=bucket.current / Decimal("1000000000"),
+                    currency="CNY",
+                )
+                for bucket in buckets
+            ]
+        )
+
+
+class DeepSeekQuotaProvider(QuotaProvider):
+    """DeepSeek 官方余额查询"""
+
+    config: DeepSeekQuotaConfig
+
+    @property
+    def api_url(self) -> str:
+        return self.config.api_url
+
+    def build_headers(self) -> dict[str, str]:
+        api_key = self.config.api_key or self.model.api_key
+        if not api_key:
+            raise QuotaError("DeepSeek 额度查询未配置 API 密钥")
+        return {
+            **super().build_headers(),
+            "Authorization": f"Bearer {api_key}",
+        }
+
+    def parse_response(self, data: object) -> QuotaResult:
+        response = DeepSeekResponse.model_validate(data)
+        return QuotaResult(
+            available=response.is_available,
+            items=[
+                QuotaItem(
+                    name=balance.currency,
+                    amount=balance.total_balance,
+                    currency=balance.currency,
+                    details=[
+                        ("赠金", balance.granted_balance),
+                        ("充值", balance.topped_up_balance),
+                    ],
+                )
+                for balance in response.balance_infos
+            ],
+        )
+
+
+QUOTA_PROVIDERS: dict[str, type[QuotaProvider]] = {
+    "aperture": ApertureQuotaProvider,
+    "deepseek": DeepSeekQuotaProvider,
+}
+"""额度 provider 注册表"""
+
+
+def _format_amount(amount: Decimal, currency: str) -> str:
+    if currency == "CNY":
+        return f"{amount:.2f} 元"
+    if currency == "USD":
+        return f"${amount:.2f}"
+    return f"{amount:.2f} {currency}"
+
+
+def format_quota(model_name: str, result: QuotaResult) -> str:
+    """把统一额度结果格式化为聊天消息"""
+    if not result.items:
+        return f"未找到 {model_name} 的额度信息"
+
+    lines = [f"{model_name} 剩余额度："]
+    if result.available is False:
+        lines.append("  当前账户无可用余额")
+    for item in result.items:
+        line = f"  {item.name}: {_format_amount(item.amount, item.currency)}"
+        if item.details:
+            details = "，".join(f"{name} {_format_amount(amount, item.currency)}" for name, amount in item.details)
+            line += f"（{details}）"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+async def get_quota(model: ModelConfig) -> str:
+    """根据模型配置选择 provider 并查询额度"""
+    if model.quota is None:
+        raise QuotaError(f"模型 {model.name} 未配置额度查询")
+    provider = QUOTA_PROVIDERS[model.quota.provider](model.quota, model)
+    return format_quota(model.name, await provider.query())

--- a/src/plugins/llm/quota.py
+++ b/src/plugins/llm/quota.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Literal
 import httpx
 from pydantic import BaseModel, ValidationError
 
+from .config import DEEPSEEK_QUOTA_API_URL
 from .providers.base import USER_AGENT
 
 if TYPE_CHECKING:
@@ -70,14 +71,27 @@ class DeepSeekResponse(BaseModel):
 class QuotaProvider(ABC):
     """额度查询 provider 基类"""
 
-    def __init__(self, config: BaseQuotaConfig, model: ModelConfig) -> None:
+    endpoint_path: str
+    """未显式配置 API 地址时追加到服务地址的路径"""
+    default_api_url: str = ""
+    """服务地址也为空时使用的最终默认地址"""
+
+    def __init__(self, config: BaseQuotaConfig, model: ModelConfig, default_base_url: str = "") -> None:
         self.config = config
         self.model = model
+        self.default_base_url = default_base_url
 
     @property
-    @abstractmethod
     def api_url(self) -> str:
         """完整的额度查询地址"""
+        if self.config.api_url:
+            return self.config.api_url
+        base_url = self.default_base_url or self.model.base_url
+        if base_url:
+            return f"{base_url.rstrip('/')}{self.endpoint_path}"
+        if self.default_api_url:
+            return self.default_api_url
+        raise QuotaError("额度查询未配置 API 地址或 LLM__BASE_URL")
 
     def build_headers(self) -> dict[str, str]:
         """构造请求头"""
@@ -109,10 +123,7 @@ class ApertureQuotaProvider(QuotaProvider):
     """Tailscale Aperture 额度查询"""
 
     config: ApertureQuotaConfig
-
-    @property
-    def api_url(self) -> str:
-        return self.config.api_url
+    endpoint_path = "/api/quotas"
 
     def build_headers(self) -> dict[str, str]:
         headers = super().build_headers()
@@ -141,10 +152,8 @@ class DeepSeekQuotaProvider(QuotaProvider):
     """DeepSeek 官方余额查询"""
 
     config: DeepSeekQuotaConfig
-
-    @property
-    def api_url(self) -> str:
-        return self.config.api_url
+    endpoint_path = "/user/balance"
+    default_api_url = DEEPSEEK_QUOTA_API_URL
 
     def build_headers(self) -> dict[str, str]:
         api_key = self.config.api_key or self.model.api_key
@@ -206,9 +215,9 @@ def format_quota(model_name: str, result: QuotaResult) -> str:
     return "\n".join(lines)
 
 
-async def get_quota(model: ModelConfig) -> str:
+async def get_quota(model: ModelConfig, default_base_url: str = "") -> str:
     """根据模型配置选择 provider 并查询额度"""
     if model.quota is None:
         raise QuotaError(f"模型 {model.name} 未配置额度查询")
-    provider = QUOTA_PROVIDERS[model.quota.provider](model.quota, model)
+    provider = QUOTA_PROVIDERS[model.quota.provider](model.quota, model, default_base_url)
     return format_quota(model.name, await provider.query())

--- a/src/plugins/llm/quota.py
+++ b/src/plugins/llm/quota.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Literal
 import httpx
 from pydantic import BaseModel, ValidationError
 
-from .config import DEEPSEEK_QUOTA_API_URL
+from .config import DEEPSEEK_QUOTA_API_URL, plugin_config
 from .providers.base import USER_AGENT
 
 if TYPE_CHECKING:
@@ -76,17 +76,16 @@ class QuotaProvider(ABC):
     default_api_url: str = ""
     """服务地址也为空时使用的最终默认地址"""
 
-    def __init__(self, config: BaseQuotaConfig, model: ModelConfig, default_base_url: str = "") -> None:
+    def __init__(self, config: BaseQuotaConfig, model: ModelConfig) -> None:
         self.config = config
         self.model = model
-        self.default_base_url = default_base_url
 
     @property
     def api_url(self) -> str:
         """完整的额度查询地址"""
         if self.config.api_url:
             return self.config.api_url
-        base_url = self.default_base_url or self.model.base_url
+        base_url = plugin_config.base_url or self.model.base_url
         if base_url:
             return f"{base_url.rstrip('/')}{self.endpoint_path}"
         if self.default_api_url:
@@ -215,9 +214,9 @@ def format_quota(model_name: str, result: QuotaResult) -> str:
     return "\n".join(lines)
 
 
-async def get_quota(model: ModelConfig, default_base_url: str = "") -> str:
+async def get_quota(model: ModelConfig) -> str:
     """根据模型配置选择 provider 并查询额度"""
     if model.quota is None:
         raise QuotaError(f"模型 {model.name} 未配置额度查询")
-    provider = QUOTA_PROVIDERS[model.quota.provider](model.quota, model, default_base_url)
+    provider = QUOTA_PROVIDERS[model.quota.provider](model.quota, model)
     return format_quota(model.name, await provider.query())

--- a/tests/plugins/llm/test_quota.py
+++ b/tests/plugins/llm/test_quota.py
@@ -37,10 +37,31 @@ async def test_aperture_quota(app: App, respx_mock: MockRouter):
         },
     )
 
-    result = await get_quota(model)
+    result = await get_quota(model, "https://global.example.com")
 
     assert result == "deepseek-aperture 剩余额度：\n  deepseek: 4.82 元"
     assert route.calls[0].request.headers["User-Agent"].startswith("CoolQBot/")
+
+
+@respx.mock(assert_all_called=True)
+async def test_quota_api_url_falls_back_to_global_base_url(app: App, respx_mock: MockRouter):
+    """未配置 api_url 时优先使用全局 LLM 服务地址并追加 provider 路径"""
+    from src.plugins.llm.config import ModelConfig
+    from src.plugins.llm.quota import get_quota
+
+    route = respx_mock.get("https://global.example.com/api/quotas").mock(
+        return_value=httpx.Response(200, json={"buckets": [{"name": "shared", "current": 1000000000}]})
+    )
+    model = ModelConfig(
+        name="aperture",
+        base_url="https://model.example.com",
+        quota={"provider": "aperture"},
+    )
+
+    result = await get_quota(model, "https://global.example.com/")
+
+    assert result == "aperture 剩余额度：\n  shared: 1.00 元"
+    assert route.call_count == 1
 
 
 @respx.mock(assert_all_called=True)
@@ -143,6 +164,7 @@ async def test_llm_quota_command_uses_selected_model(app: App, respx_mock: MockR
             ),
         ],
     )
+    mocker.patch.object(plugin_config, "base_url", "https://api.deepseek.com")
     respx_mock.get("https://api.deepseek.com/user/balance").mock(
         return_value=httpx.Response(
             200,

--- a/tests/plugins/llm/test_quota.py
+++ b/tests/plugins/llm/test_quota.py
@@ -1,0 +1,198 @@
+"""测试模型额度查询"""
+
+import httpx
+import pytest
+import respx
+from nonebot import get_adapter
+from nonebot.adapters.onebot.v11 import Adapter, Bot, Message
+from nonebug import App
+from respx import MockRouter
+
+from tests.fake import fake_group_message_event_v11
+
+
+@respx.mock(assert_all_called=True)
+async def test_aperture_quota(app: App, respx_mock: MockRouter):
+    """Aperture provider 解析纳元额度桶并支持按桶筛选"""
+    from src.plugins.llm.config import ModelConfig
+    from src.plugins.llm.quota import get_quota
+
+    route = respx_mock.get("https://ai.example.com/api/quotas").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "buckets": [
+                    {"name": "other", "current": 1000000000},
+                    {"name": "deepseek", "current": 4820000000},
+                ]
+            },
+        )
+    )
+    model = ModelConfig(
+        name="deepseek-aperture",
+        quota={
+            "provider": "aperture",
+            "api_url": "https://ai.example.com/api/quotas",
+            "bucket": "deepseek",
+        },
+    )
+
+    result = await get_quota(model)
+
+    assert result == "deepseek-aperture 剩余额度：\n  deepseek: 4.82 元"
+    assert route.calls[0].request.headers["User-Agent"].startswith("CoolQBot/")
+
+
+@respx.mock(assert_all_called=True)
+async def test_deepseek_quota(app: App, respx_mock: MockRouter):
+    """DeepSeek provider 复用模型密钥并显示充值与赠金余额"""
+    from src.plugins.llm.config import DEEPSEEK_QUOTA_API_URL, ModelConfig
+    from src.plugins.llm.quota import get_quota
+
+    route = respx_mock.get(DEEPSEEK_QUOTA_API_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "is_available": True,
+                "balance_infos": [
+                    {
+                        "currency": "CNY",
+                        "total_balance": "110.00",
+                        "granted_balance": "10.00",
+                        "topped_up_balance": "100.00",
+                    },
+                    {
+                        "currency": "USD",
+                        "total_balance": "15.25",
+                        "granted_balance": "1.25",
+                        "topped_up_balance": "14.00",
+                    },
+                ],
+            },
+        )
+    )
+    model = ModelConfig(
+        name="deepseek",
+        api_key="sk-model",
+        quota={"provider": "deepseek"},
+    )
+
+    result = await get_quota(model)
+
+    assert result == (
+        "deepseek 剩余额度：\n"
+        "  CNY: 110.00 元（赠金 10.00 元，充值 100.00 元）\n"
+        "  USD: $15.25（赠金 $1.25，充值 $14.00）"
+    )
+    assert route.calls[0].request.headers["Authorization"] == "Bearer sk-model"
+
+
+async def test_deepseek_quota_without_api_key(app: App):
+    """DeepSeek 额度查询缺少密钥时给出明确错误"""
+    from src.plugins.llm.config import ModelConfig
+    from src.plugins.llm.quota import QuotaError, get_quota
+
+    model = ModelConfig(name="deepseek", quota={"provider": "deepseek"})
+
+    with pytest.raises(QuotaError, match="未配置 API 密钥"):
+        await get_quota(model)
+
+
+@respx.mock(assert_all_called=True)
+async def test_quota_http_error(app: App, respx_mock: MockRouter):
+    """额度 API 出错时不向聊天消息泄露响应内容"""
+    from src.plugins.llm.config import ModelConfig
+    from src.plugins.llm.quota import QuotaError, get_quota
+
+    respx_mock.get("https://ai.example.com/api/quotas").mock(
+        return_value=httpx.Response(401, json={"error": "secret detail"})
+    )
+    model = ModelConfig(
+        name="aperture",
+        quota={"provider": "aperture", "api_url": "https://ai.example.com/api/quotas"},
+    )
+
+    with pytest.raises(QuotaError, match="获取额度信息失败，请稍后再试"):
+        await get_quota(model)
+
+
+async def test_quota_not_configured(app: App):
+    """模型未配置额度 provider 时给出明确错误"""
+    from src.plugins.llm.config import ModelConfig
+    from src.plugins.llm.quota import QuotaError, get_quota
+
+    with pytest.raises(QuotaError, match="模型 test-model 未配置额度查询"):
+        await get_quota(ModelConfig(name="test-model"))
+
+
+@respx.mock(assert_all_called=True)
+async def test_llm_quota_command_uses_selected_model(app: App, respx_mock: MockRouter, mocker):
+    """/llm quota 可指定模型，并调用该模型自己的额度 provider"""
+    from src.plugins.llm import llm_cmd
+    from src.plugins.llm.config import ModelConfig, plugin_config
+
+    mocker.patch.object(
+        plugin_config,
+        "models",
+        [
+            ModelConfig(name="without-quota"),
+            ModelConfig(
+                name="deepseek",
+                api_key="sk-test",
+                quota={"provider": "deepseek"},
+            ),
+        ],
+    )
+    respx_mock.get("https://api.deepseek.com/user/balance").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "is_available": False,
+                "balance_infos": [
+                    {
+                        "currency": "CNY",
+                        "total_balance": "0.00",
+                        "granted_balance": "0.00",
+                        "topped_up_balance": "0.00",
+                    }
+                ],
+            },
+        )
+    )
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter)
+        event = fake_group_message_event_v11(message=Message("/llm quota deepseek"))
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(
+            event,
+            "deepseek 剩余额度：\n  当前账户无可用余额\n  CNY: 0.00 元（赠金 0.00 元，充值 0.00 元）",
+            True,
+            at_sender=True,
+        )
+        ctx.should_finished(llm_cmd)
+
+
+async def test_llm_quota_command_defaults_to_current_model(app: App, mocker):
+    """/llm quota 默认查询群组当前模型"""
+    from src.plugins.llm import llm_cmd
+    from src.plugins.llm.config import ModelConfig, plugin_config
+    from src.plugins.llm.data_source import set_model_name
+
+    mocker.patch.object(
+        plugin_config,
+        "models",
+        [ModelConfig(name="first"), ModelConfig(name="current")],
+    )
+    await set_model_name("QQClient_10000", "current")
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter)
+        event = fake_group_message_event_v11(message=Message("/llm quota"))
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "模型 current 未配置额度查询", True, at_sender=True)
+        ctx.should_finished(llm_cmd)

--- a/tests/plugins/llm/test_quota.py
+++ b/tests/plugins/llm/test_quota.py
@@ -37,16 +37,16 @@ async def test_aperture_quota(app: App, respx_mock: MockRouter):
         },
     )
 
-    result = await get_quota(model, "https://global.example.com")
+    result = await get_quota(model)
 
     assert result == "deepseek-aperture 剩余额度：\n  deepseek: 4.82 元"
     assert route.calls[0].request.headers["User-Agent"].startswith("CoolQBot/")
 
 
 @respx.mock(assert_all_called=True)
-async def test_quota_api_url_falls_back_to_global_base_url(app: App, respx_mock: MockRouter):
+async def test_quota_api_url_falls_back_to_global_base_url(app: App, respx_mock: MockRouter, mocker):
     """未配置 api_url 时优先使用全局 LLM 服务地址并追加 provider 路径"""
-    from src.plugins.llm.config import ModelConfig
+    from src.plugins.llm.config import ModelConfig, plugin_config
     from src.plugins.llm.quota import get_quota
 
     route = respx_mock.get("https://global.example.com/api/quotas").mock(
@@ -57,17 +57,18 @@ async def test_quota_api_url_falls_back_to_global_base_url(app: App, respx_mock:
         base_url="https://model.example.com",
         quota={"provider": "aperture"},
     )
+    mocker.patch.object(plugin_config, "base_url", "https://global.example.com/")
 
-    result = await get_quota(model, "https://global.example.com/")
+    result = await get_quota(model)
 
     assert result == "aperture 剩余额度：\n  shared: 1.00 元"
     assert route.call_count == 1
 
 
 @respx.mock(assert_all_called=True)
-async def test_deepseek_quota(app: App, respx_mock: MockRouter):
+async def test_deepseek_quota(app: App, respx_mock: MockRouter, mocker):
     """DeepSeek provider 复用模型密钥并显示充值与赠金余额"""
-    from src.plugins.llm.config import DEEPSEEK_QUOTA_API_URL, ModelConfig
+    from src.plugins.llm.config import DEEPSEEK_QUOTA_API_URL, ModelConfig, plugin_config
     from src.plugins.llm.quota import get_quota
 
     route = respx_mock.get(DEEPSEEK_QUOTA_API_URL).mock(
@@ -97,6 +98,7 @@ async def test_deepseek_quota(app: App, respx_mock: MockRouter):
         api_key="sk-model",
         quota={"provider": "deepseek"},
     )
+    mocker.patch.object(plugin_config, "base_url", "")
 
     result = await get_quota(model)
 


### PR DESCRIPTION
## 概要

- 为单个 LLM 模型增加可判别的 `quota` provider 配置，并提供统一的额度查询与格式化接口
- 新增 `/llm quota [模型名]`，未指定模型时查询群组当前模型
- 支持 Aperture `/api/quotas`，包括额度桶筛选和纳元换算
- 支持 DeepSeek `/user/balance`，复用模型密钥并展示总余额、赠金和充值余额
- `quota.api_url` 未设置时直接读取 `plugin_config.base_url`（即 `LLM__BASE_URL`）并追加 provider 路径；显式完整地址仍可覆盖
- 补充配置文档、更新日志以及 provider/命令测试

## 测试

- `python -m pytest tests/plugins/llm -q`：61 passed
- `ruff check`：通过
- `pyright`：0 errors
- pre-commit：Ruff、Ruff Format、Prettier 全部通过
- 全量测试：243 passed，1 failed；失败用例 `test_dps_missing_token` 要求未配置 `FFLOGS_TOKEN`，但本机 `.env` 已配置。临时设置 `FFLOGS_TOKEN=''` 后该用例单独通过

额度 API 均使用模拟响应测试，未请求真实账户余额。