### PR TITLE
feat(llm): 优化回复显示与状态反馈

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 - 添加大模型对话插件 (llm)，支持 Chat Completions、Responses 与 Anthropic Messages 三种 API 格式、全局和模型级服务地址配置、响应耗时与 token 用量尾注、会话亲和请求头、Aperture 与 DeepSeek 模型额度查询，以及天气和节假日工具调用
 - 为 `/llm quota` 添加 `/quota` 与 `/额度` 快捷命令
 
+### Changed
+
+- 优化 llm 回复显示：推理内容改用引用块，并通过 emoji reaction 反馈响应状态
+
 ### Fixed
 
 - 修正 llm 对话选项位置与 TTS 模型设置命令的使用说明

--- a/src/plugins/llm/README.md
+++ b/src/plugins/llm/README.md
@@ -17,7 +17,8 @@
 
 - 单轮与多轮对话，多轮支持「结束」「回滚」指令
 - 流式与非流式请求
-- 推理内容展示（DeepSeek 的 `reasoning_content`、Anthropic 的 `thinking`、Responses 的推理摘要）
+- 推理内容以引用块展示（DeepSeek 的 `reasoning_content`、Anthropic 的 `thinking`、Responses 的推理摘要）
+- 使用 emoji reaction 反馈响应状态（思考中、已完成、失败；不支持的平台自动跳过）
 - 工具调用（function calling），三种格式自动适配
 - 图片输入（多模态）
 - 在回复末尾显示整轮耗时、实际模型和 token 用量，工具调用产生的多次请求会累计统计

--- a/src/plugins/llm/__init__.py
+++ b/src/plugins/llm/__init__.py
@@ -249,20 +249,14 @@ async def _handle_with_context(
     await handler.send(completion)
 
     while True:
-        reply_message_id: str | None = None
-
-        def receive_reply(reply_event: Event):
-            nonlocal reply_message_id
-            reply_message_id = get_message_id(reply_event)
-            return reply_event.get_message()
-
-        reply = await prompt(
+        received = await prompt(
             "继续对话吧（发送「结束」结束对话，「回滚」撤销上一轮）",
-            handler=receive_reply,
+            handler=_extract_reply,
             timeout=plugin_config.context_timeout,
         )
-        if reply is None:
+        if received is None:
             await UniMessage.text("等待超时，已结束对话").finish()
+        reply, reply_message_id = received
 
         message = reply.extract_plain_text().strip()
         if message in ("结束", "取消"):
@@ -278,6 +272,11 @@ async def _handle_with_context(
 
         completion = await _ask(handler, message, None, message_id=reply_message_id)
         await handler.send(completion)
+
+
+def _extract_reply(reply_event: Event):
+    """提取续聊消息，并在 waiter 事件上下文中保存其消息 ID"""
+    return reply_event.get_message(), get_message_id(reply_event)
 
 
 async def _ask(

--- a/src/plugins/llm/__init__.py
+++ b/src/plugins/llm/__init__.py
@@ -27,6 +27,7 @@ from nonebot_plugin_alconna import (
     Query,
     Subcommand,
     UniMessage,
+    get_message_id,
     image_fetch,
     on_alconna,
 )
@@ -39,7 +40,7 @@ from src.utils.helpers import admin_permission
 
 from .config import plugin_config
 from .data_source import get_model_name, get_tts_model, set_model_name, set_tts_model
-from .handler import LLMHandler
+from .handler import LLMHandler, send_reaction
 from .providers import ProviderError
 from .quota import QuotaError, get_quota
 from .schemas import ImageContent
@@ -248,8 +249,16 @@ async def _handle_with_context(
     await handler.send(completion)
 
     while True:
+        reply_message_id: str | None = None
+
+        def receive_reply(reply_event: Event):
+            nonlocal reply_message_id
+            reply_message_id = get_message_id(reply_event)
+            return reply_event.get_message()
+
         reply = await prompt(
             "继续对话吧（发送「结束」结束对话，「回滚」撤销上一轮）",
+            handler=receive_reply,
             timeout=plugin_config.context_timeout,
         )
         if reply is None:
@@ -267,18 +276,31 @@ async def _handle_with_context(
         if not message:
             continue
 
-        completion = await _ask(handler, message, None)
+        completion = await _ask(handler, message, None, message_id=reply_message_id)
         await handler.send(completion)
 
 
-async def _ask(handler: LLMHandler, text: str, images: list[ImageContent] | None):
+async def _ask(
+    handler: LLMHandler,
+    text: str,
+    images: list[ImageContent] | None,
+    *,
+    message_id: str | None = None,
+):
     """请求模型，失败时结束当前会话并提示原因"""
+    await send_reaction("thinking", message_id=message_id)
     try:
-        return await handler.ask(text, images)
+        completion = await handler.ask(text, images)
     except ProviderError as e:
+        await send_reaction("fail", message_id=message_id)
         await llm_cmd.finish(f"调用失败：{e}", at_sender=True)
     except ValueError as e:
+        await send_reaction("fail", message_id=message_id)
         await llm_cmd.finish(str(e), at_sender=True)
     except Exception as e:
         logger.opt(exception=e).error("大模型调用出现未预期的错误")
+        await send_reaction("fail", message_id=message_id)
         await llm_cmd.finish("调用失败，请稍后重试", at_sender=True)
+
+    await send_reaction("done", message_id=message_id)
+    return completion

--- a/src/plugins/llm/handler.py
+++ b/src/plugins/llm/handler.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 import asyncio
 import re
 from time import perf_counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from uuid import uuid4
 
 from nonebot.log import logger
-from nonebot_plugin_alconna import UniMessage
+from nonebot_plugin_alconna import SupportAdapter, UniMessage, get_target, message_reaction
 
 from .config import plugin_config
 from .providers import ProviderError, get_provider
@@ -27,8 +27,13 @@ if TYPE_CHECKING:
 THINK_PATTERN = re.compile(r"<think>(.*?)</think>", re.DOTALL)
 """部分服务商把推理内容混在正文的 think 标签里"""
 
-THINKING_SEPARATOR = "\n\n--------------------\n\n"
-"""推理内容与正文之间的分隔线"""
+ReactionStatus = Literal["fail", "thinking", "done"]
+REACTION_EMOJIS: dict[ReactionStatus, tuple[str, str]] = {
+    "fail": ("10060", "❌"),
+    "thinking": ("424", "👀"),
+    "done": ("144", "🎉"),
+}
+"""QQ emoji ID 与其他平台 Unicode emoji 的对应关系"""
 
 
 async def chat(model_name: str, messages: list[Message], *, session_affinity: str = "") -> Completion:
@@ -66,17 +71,41 @@ def format_statistics(completion: Completion) -> str:
     )
 
 
+def format_thinking(reasoning: str) -> str:
+    """把推理内容格式化为 Markdown 引用块"""
+    return "\n".join(f"> {line}" if line else ">" for line in reasoning.splitlines())
+
+
 def format_output(completion: Completion, *, with_thinking: bool, with_statistics: bool = True) -> str:
     """把模型回复格式化为最终文本"""
     content, reasoning = split_content(completion)
     if with_thinking and reasoning:
-        text = f"{reasoning}{THINKING_SEPARATOR}{content}" if content else reasoning
+        thinking = format_thinking(reasoning)
+        text = f"{thinking}\n\n{content}" if content else thinking
     else:
         text = content
 
     if text and with_statistics:
         return f"{text}\n\n{format_statistics(completion)}"
     return text
+
+
+async def send_reaction(
+    status: ReactionStatus,
+    *,
+    message_id: str | None = None,
+) -> None:
+    """给触发消息添加响应状态；平台不支持或调用失败时静默跳过"""
+    try:
+        target = get_target()
+        is_qq = target.adapter in (SupportAdapter.onebot11, SupportAdapter.qq)
+        if is_qq and target.private:
+            return
+
+        emoji = REACTION_EMOJIS[status][0 if is_qq else 1]
+        await message_reaction(emoji, message_id=message_id)
+    except Exception as e:
+        logger.opt(exception=e).debug("添加大模型响应状态失败，已忽略")
 
 
 async def execute_tool_calls(calls: list[ToolCall], context: list[Message]) -> None:

--- a/tests/plugins/llm/test_data_source.py
+++ b/tests/plugins/llm/test_data_source.py
@@ -1,5 +1,7 @@
 """测试群组配置与工具注册表"""
 
+from types import SimpleNamespace
+
 import pytest
 from nonebug import App
 
@@ -202,3 +204,62 @@ def test_split_content_extracts_think_tags(app: App):
 
     assert content == "你好"
     assert reasoning == "在想"
+
+
+def test_format_output_quotes_multiline_thinking(app: App):
+    """推理内容使用 Markdown 引用块，并保留段落结构"""
+    from src.plugins.llm.handler import format_output
+    from src.plugins.llm.schemas import Completion, Message
+
+    completion = Completion(message=Message.assistant(content="回答", reasoning="第一段\n\n第二段"))
+
+    assert format_output(completion, with_thinking=True, with_statistics=False) == "> 第一段\n>\n> 第二段\n\n回答"
+
+
+@pytest.mark.parametrize(
+    ("adapter", "status", "expected"),
+    [
+        ("OneBot V11", "thinking", "424"),
+        ("Discord", "done", "🎉"),
+    ],
+)
+async def test_send_reaction_uses_adapter_emoji(app: App, mocker, adapter, status, expected):
+    """QQ 使用 emoji ID，其他平台使用 Unicode emoji"""
+    from src.plugins.llm.handler import send_reaction
+
+    get_target = mocker.patch(
+        "src.plugins.llm.handler.get_target",
+        return_value=SimpleNamespace(adapter=adapter, private=False),
+    )
+    reaction = mocker.patch("src.plugins.llm.handler.message_reaction")
+
+    await send_reaction(status, message_id="42")
+
+    get_target.assert_called_once_with()
+    reaction.assert_awaited_once_with(expected, message_id="42")
+
+
+async def test_send_reaction_skips_qq_private_message(app: App, mocker):
+    """QQ 私聊不支持消息 reaction，直接跳过"""
+    from nonebot_plugin_alconna import SupportAdapter
+
+    from src.plugins.llm.handler import send_reaction
+
+    mocker.patch(
+        "src.plugins.llm.handler.get_target",
+        return_value=SimpleNamespace(adapter=SupportAdapter.onebot11, private=True),
+    )
+    reaction = mocker.patch("src.plugins.llm.handler.message_reaction")
+
+    await send_reaction("thinking")
+
+    reaction.assert_not_awaited()
+
+
+async def test_send_reaction_failure_does_not_interrupt_response(app: App, mocker):
+    """reaction 不可用时不影响后续模型请求"""
+    from src.plugins.llm.handler import send_reaction
+
+    mocker.patch("src.plugins.llm.handler.get_target", side_effect=RuntimeError("unsupported"))
+
+    await send_reaction("thinking")

--- a/tests/plugins/llm/test_llm.py
+++ b/tests/plugins/llm/test_llm.py
@@ -1,6 +1,7 @@
 """测试 /llm 命令"""
 
 import json
+from unittest.mock import call
 from uuid import UUID
 
 import httpx
@@ -27,7 +28,8 @@ def mock_models(mocker):
     )
     mocker.patch.object(plugin_config, "models", [config])
     mocker.patch("src.plugins.llm.handler.perf_counter", side_effect=[10.0, 15.1])
-    return config
+    reaction = mocker.patch("src.plugins.llm.send_reaction")
+    return config, reaction
 
 
 def test_session_affinity_is_per_conversation(app: App, mock_models):
@@ -96,6 +98,12 @@ async def test_llm_chat(app: App, respx_mock: MockRouter, mock_models):
             True,
         )
 
+    _, reaction = mock_models
+    assert reaction.await_args_list == [
+        call("thinking", message_id=None),
+        call("done", message_id=None),
+    ]
+
     request = route.calls[0].request
     assert UUID(request.headers["x-session-affinity"]).version == 4
 
@@ -118,7 +126,6 @@ async def test_llm_rejects_unknown_model(app: App, mock_models):
 async def test_llm_with_thinking(app: App, respx_mock: MockRouter, mock_models, mocker):
     """开启推理内容展示时附带思考过程"""
     from src.plugins.llm.config import plugin_config
-    from src.plugins.llm.handler import THINKING_SEPARATOR
 
     mocker.patch.object(plugin_config, "send_thinking", True)
 
@@ -145,7 +152,7 @@ async def test_llm_with_thinking(app: App, respx_mock: MockRouter, mock_models, 
         ctx.receive_event(bot, event)
         ctx.should_call_send(
             event,
-            Message(f"在想{THINKING_SEPARATOR}你好呀\n\n--- 5.1s  test-model  I:0 O:0 A:0 C:0"),
+            Message("> 在想\n\n你好呀\n\n--- 5.1s  test-model  I:0 O:0 A:0 C:0"),
             True,
         )
 
@@ -285,6 +292,12 @@ async def test_llm_error_raises(app: App, respx_mock: MockRouter, mock_models):
         ctx.receive_event(bot, event)
         ctx.should_call_send(event, "调用失败：无效的密钥", True, at_sender=True)
         ctx.should_finished(llm_cmd)
+
+    _, reaction = mock_models
+    assert reaction.await_args_list == [
+        call("thinking", message_id=None),
+        call("fail", message_id=None),
+    ]
 
 
 @respx.mock(assert_all_called=True)

--- a/tests/plugins/llm/test_llm.py
+++ b/tests/plugins/llm/test_llm.py
@@ -44,6 +44,49 @@ def test_session_affinity_is_per_conversation(app: App, mock_models):
     assert first.session_affinity != second.session_affinity
 
 
+def test_extract_context_reply_keeps_message_id(app: App, mocker):
+    """续聊消息在 waiter 的事件上下文中保存消息 ID"""
+    from src.plugins.llm import _extract_reply
+
+    event = fake_group_message_event_v11(message=Message("继续聊"), message_id=42)
+    get_message_id = mocker.patch("src.plugins.llm.get_message_id", return_value="42")
+
+    message, message_id = _extract_reply(event)
+
+    assert message == event.get_message()
+    assert message_id == "42"
+    get_message_id.assert_called_once_with(event)
+
+
+async def test_context_reply_reacts_to_current_message(app: App, mocker):
+    """多轮续聊把当前消息 ID 传给模型响应流程"""
+    from src.plugins.llm import _handle_with_context
+
+    class StopConversation(Exception):
+        pass
+
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    first_completion = object()
+    ask = mocker.patch(
+        "src.plugins.llm._ask",
+        side_effect=[first_completion, StopConversation],
+    )
+    mocker.patch(
+        "nonebot_plugin_waiter.prompt",
+        return_value=(Message("继续聊"), "42"),
+    )
+
+    with pytest.raises(StopConversation):
+        await _handle_with_context(handler, "开始", None)
+
+    assert ask.await_args_list == [
+        call(handler, "开始", None),
+        call(handler, "继续聊", None, message_id="42"),
+    ]
+    handler.send.assert_awaited_once_with(first_completion)
+
+
 @pytest.mark.asyncio
 async def test_llm_not_configured(app: App):
     """未配置任何模型时的提示"""


### PR DESCRIPTION
## 概要

- 将模型思考内容格式化为 Markdown 引用块，改善正文层次
- 参照 nonebot-plugin-deepseek 添加 👀 / 🎉 / ❌ 响应状态 reaction
- 对 QQ/OneBot 使用数字 emoji ID，跳过 QQ 私聊及不支持的平台
- 在多轮对话中记录每轮输入的消息 ID，确保 reaction 反馈到正确消息
- 同步插件文档、变更日志与行为测试

## 验证

- `uv run pytest tests/plugins/llm -q`（71 passed）
- `uv run pytest tests/plugins/llm/test_llm.py --cov=src/plugins/llm --cov-report=term-missing:skip-covered -q`
- `uv run pre-commit run --files CHANGELOG.md src/plugins/llm/README.md src/plugins/llm/__init__.py src/plugins/llm/handler.py tests/plugins/llm/test_data_source.py tests/plugins/llm/test_llm.py`
- `git diff --check`
- 使用 htmlrender 实际渲染引用块预览并完成视觉检查