### PR TITLE
fix(renovate): 同步 Pyright Python 版本

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,9 +12,11 @@
   customManagers: [
     {
       customType: "regex",
+      description: "Update Pyright Python version",
       managerFilePatterns: ["/^pyproject\\.toml$/"],
       matchStrings: ['pythonVersion\\s*=\\s*"(?<currentValue>\\d+\\.\\d+)"'],
       depNameTemplate: "python",
+      depTypeTemplate: "tool.pyright",
       datasourceTemplate: "python-version",
       versioningTemplate: "python",
       extractVersionTemplate: "^(?<version>\\d+\\.\\d+)",
@@ -85,6 +87,7 @@
       groupName: "Project Python version",
       matchPackageNames: ["python"],
       matchManagers: ["pep621", "custom.regex"],
+      matchDepTypes: ["requires-python", "tool.pyright"],
       matchUpdateTypes: ["major", "minor"],
       description: "Weekly update of project Python version",
     },

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,17 @@
   labels: ["dependencies"],
   rangeStrategy: "bump",
   ignoreDeps: ["eorzeaenv"],
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^pyproject\\.toml$/"],
+      matchStrings: ['pythonVersion\\s*=\\s*"(?<currentValue>\\d+\\.\\d+)"'],
+      depNameTemplate: "python",
+      datasourceTemplate: "python-version",
+      versioningTemplate: "python",
+      extractVersionTemplate: "^(?<version>\\d+\\.\\d+)",
+    },
+  ],
   packageRules: [
     {
       groupName: "NoneBot adapters",
@@ -73,7 +84,7 @@
     {
       groupName: "Project Python version",
       matchPackageNames: ["python"],
-      matchManagers: ["pep621"],
+      matchManagers: ["pep621", "custom.regex"],
       matchUpdateTypes: ["major", "minor"],
       description: "Weekly update of project Python version",
     },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ nonebot-plugin-parser = ["nonebot_plugin_parser"]
 "@local" = []
 
 [tool.pyright]
-pythonVersion = "3.13"
+pythonVersion = "3.14"
 pythonPlatform = "All"
 typeCheckingMode = "standard"
 


### PR DESCRIPTION
## 概要

- 为 `tool.pyright.pythonVersion` 添加 Renovate regex custom manager
- 将 `custom.regex` 纳入 `Project Python version` 分组，与 `project.requires-python` 同步更新
- 将当前 Pyright 目标版本由 Python 3.13 对齐到项目要求的 Python 3.14
- 将 Python 补丁版本归一化为 Pyright 使用的 major.minor 格式

## 验证

- [x] Renovate 44.7.2 配置校验
- [x] Renovate 定向提取、版本归一化、替换和分组验证
- [x] Prettier 检查
- [x] `uv lock --check`
- [x] `uv run ruff check .`
- [x] 提交钩子

## 说明

全量 Pyright 在 Python 3.13 和 3.14 配置下均存在相同的 7 个既有类型错误，本次变更没有引入新的类型错误。