### PR TITLE
fix(llm): 工具达到轮数上限后生成收尾回复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复 SQLite 单连接池导致并发会话互相回滚、群级 LLM 配置写入误报成功的问题
+- 修复大模型工具调用达到轮数上限后直接失败的问题，改为基于已有结果生成收尾回复
 
 ### Removed
 

--- a/src/plugins/llm/README.md
+++ b/src/plugins/llm/README.md
@@ -160,8 +160,8 @@ LLM__MD_TO_PIC=false
 LLM__RESPOND_TO_MENTION=true
 # 是否流式请求
 LLM__STREAM=false
-# 单次提问允许的最大工具调用轮数
-LLM__MAX_TOOL_ROUNDS=5
+# 单次提问允许的最大工具调用轮数，达到上限后会禁用工具并基于已有结果收尾
+LLM__MAX_TOOL_ROUNDS=10
 # 工具调用开始后首次提示与后续重复提示的间隔（秒）
 LLM__TOOL_NOTICE_DELAY=2
 LLM__TOOL_NOTICE_INTERVAL=30

--- a/src/plugins/llm/config.py
+++ b/src/plugins/llm/config.py
@@ -122,8 +122,8 @@ class ScopedConfig(BaseModel):
     """是否响应被适配器判定为发给机器人的消息（如群聊 @）"""
     context_timeout: int = 120
     """多轮对话中等待用户输入的超时时间（秒）"""
-    max_tool_rounds: int = 5
-    """单次提问中允许的最大工具调用轮数，防止模型陷入循环"""
+    max_tool_rounds: int = 10
+    """单次提问中允许的最大工具调用轮数，达到上限后禁用工具生成收尾回复"""
     tool_notice_delay: float = Field(default=10.0, ge=0)
     """发现工具调用后首次发送等待提示前的秒数"""
     tool_notice_interval: float = Field(default=60.0, gt=0)

--- a/src/plugins/llm/handler.py
+++ b/src/plugins/llm/handler.py
@@ -30,6 +30,11 @@ if TYPE_CHECKING:
 THINK_PATTERN = re.compile(r"<think>(.*?)</think>", re.DOTALL)
 """部分服务商把推理内容混在正文的 think 标签里"""
 
+TOOL_ROUND_LIMIT_PROMPT = (
+    "工具调用轮数已达到上限。请停止调用工具，仅根据已经获取的信息直接回答用户；如果信息不足，请明确说明尚未完成的部分。"
+)
+"""工具调用达到上限后用于强制生成收尾回复的临时提示词。"""
+
 ReactionStatus = Literal["fail", "thinking", "done"]
 ToolWaitNotifier = Callable[[int, int, int], Awaitable[None]]
 REACTION_EMOJIS: dict[ReactionStatus, tuple[str, str]] = {
@@ -172,8 +177,8 @@ class LLMHandler:
     ) -> Completion:
         """追加一轮用户输入并请求模型
 
-        模型请求工具调用时自动执行并继续请求，直到给出最终回复
-        或达到 `max_tool_rounds` 轮数上限。
+        模型请求工具调用时自动执行并继续请求，直到给出最终回复；
+        达到 `max_tool_rounds` 轮数上限后禁用工具生成收尾回复。
         """
         if images and "vision" not in plugin_config.get_model(self.model_name).capabilities:
             raise ValueError(f"模型 {self.model_name} 未声明 vision 能力，不能接收图片")
@@ -235,6 +240,33 @@ class LLMHandler:
                 )
                 total_usage = total_usage + completion.usage
                 actual_model = completion.model or actual_model
+
+            if completion.tool_calls:
+                logger.warning(
+                    "LLM 会话工具调用达到上限，转为无工具收尾（会话={}，上限={}，未执行调用={}）",
+                    self.log_id,
+                    plugin_config.max_tool_rounds,
+                    len(completion.tool_calls),
+                )
+                final_context = list(self.context)
+                first_non_system = next(
+                    (index for index, message in enumerate(final_context) if message.role != "system"),
+                    len(final_context),
+                )
+                final_context.insert(first_non_system, Message(role="system", content=TOOL_ROUND_LIMIT_PROMPT))
+                tool_progress.request_count += 1
+                try:
+                    completion = await chat(
+                        self.model_name,
+                        final_context,
+                        session_affinity=self.session_affinity,
+                        enable_tools=False,
+                    )
+                except Exception:
+                    del self.context[context_start:]
+                    raise
+                total_usage = total_usage + completion.usage
+                actual_model = completion.model or actual_model
         finally:
             if notice_task:
                 notice_task.cancel()
@@ -244,12 +276,12 @@ class LLMHandler:
         if completion.tool_calls:
             del self.context[context_start:]
             logger.warning(
-                "LLM 会话工具调用超过上限（会话={}，上限={}，待执行调用={}）",
+                "LLM 会话无工具收尾仍返回工具调用（会话={}，上限={}，调用数量={}）",
                 self.log_id,
                 plugin_config.max_tool_rounds,
                 len(completion.tool_calls),
             )
-            raise ProviderError(f"工具调用超过上限（{plugin_config.max_tool_rounds} 轮）")
+            raise ProviderError(f"工具调用达到上限后仍未生成最终回复（{plugin_config.max_tool_rounds} 轮）")
 
         completion.usage = total_usage
         completion.model = actual_model or plugin_config.resolve(self.model_name).model

--- a/tests/plugins/llm/test_data_source.py
+++ b/tests/plugins/llm/test_data_source.py
@@ -205,7 +205,7 @@ async def test_set_and_get_tts_model(app: App, mocker):
 
 
 def test_model_config_defaults(app: App):
-    """模型配置的默认值：model 跟随 name，解析时按格式选取 base_url"""
+    """模型配置的默认值：模型名、服务地址和工具轮数。"""
     from src.plugins.llm.config import ModelConfig, ScopedConfig
 
     chat = ModelConfig(name="deepseek-chat")
@@ -222,6 +222,7 @@ def test_model_config_defaults(app: App):
     assert anthropic.capabilities == {"vision"}
 
     config = ScopedConfig(models=[chat, anthropic])
+    assert config.max_tool_rounds == 10
     assert config.tool_notice_delay == 10.0
     assert config.tool_notice_interval == 60.0
     assert config.resolve("deepseek-chat").base_url == "https://api.deepseek.com"

--- a/tests/plugins/llm/test_llm.py
+++ b/tests/plugins/llm/test_llm.py
@@ -528,8 +528,64 @@ async def test_tool_wait_notice_repeats_until_final_completion(app: App, mock_mo
     assert notices == [(1, 1, 1), (2, 2, 1)]
 
 
-async def test_tool_round_limit_rolls_back_current_question(app: App, mock_models, mocker):
-    """工具调用超过轮数上限时不保留不完整的上下文"""
+async def test_tool_round_limit_generates_final_response_without_tools(app: App, mock_models, mocker):
+    """达到工具轮数上限后基于已有结果生成无工具收尾回复。"""
+    from src.plugins.llm.config import plugin_config
+    from src.plugins.llm.handler import TOOL_ROUND_LIMIT_PROMPT, LLMHandler
+    from src.plugins.llm.schemas import Completion, Message, ToolCall, Usage
+
+    first_tool_completion = Completion(
+        message=Message.assistant(tool_calls=[ToolCall(id="call_1", name="get_weather", arguments={})]),
+        finish_reason="tool_calls",
+        usage=Usage(input_tokens=1, output_tokens=2),
+        model="first-model",
+    )
+    pending_tool_completion = Completion(
+        message=Message.assistant(tool_calls=[ToolCall(id="call_2", name="web_search", arguments={})]),
+        finish_reason="tool_calls",
+        usage=Usage(input_tokens=3, output_tokens=4),
+        model="second-model",
+    )
+    final_completion = Completion(
+        message=Message.assistant(content="根据已有天气信息：晴。"),
+        finish_reason="stop",
+        usage=Usage(input_tokens=5, output_tokens=6),
+        model="final-model",
+    )
+    mocker.patch.object(plugin_config, "max_tool_rounds", 1)
+    chat = mocker.patch(
+        "src.plugins.llm.handler.chat",
+        side_effect=[first_tool_completion, pending_tool_completion, final_completion],
+    )
+
+    async def execute(calls, context):
+        context.append(Message.tool(calls[0].id, "晴"))
+
+    execute_calls = mocker.patch("src.plugins.llm.handler.execute_tool_calls", side_effect=execute)
+    handler = LLMHandler("test-model", system_prompt="测试人设")
+
+    completion = await handler.ask("天气")
+
+    assert completion.content == "根据已有天气信息：晴。"
+    assert completion.usage == Usage(input_tokens=9, output_tokens=12)
+    assert completion.model == "final-model"
+    assert [message.role for message in handler.context] == ["system", "user", "assistant", "tool", "assistant"]
+    assert handler.context[-1] is completion.message
+    execute_calls.assert_awaited_once()
+    assert execute_calls.await_args.args[0] == first_tool_completion.tool_calls
+    assert execute_calls.await_args.args[1] is handler.context
+    assert chat.await_count == 3
+    final_call = chat.await_args_list[-1]
+    assert final_call.kwargs == {"session_affinity": handler.session_affinity, "enable_tools": False}
+    assert final_call.args[1][:2] == [
+        Message(role="system", content="测试人设"),
+        Message(role="system", content=TOOL_ROUND_LIMIT_PROMPT),
+    ]
+    assert final_call.args[1][2:] == handler.context[1:-1]
+
+
+async def test_tool_round_limit_rolls_back_when_final_response_still_calls_tools(app: App, mock_models, mocker):
+    """无工具收尾仍返回工具调用时不保留不完整的上下文。"""
     from src.plugins.llm.config import plugin_config
     from src.plugins.llm.handler import LLMHandler
     from src.plugins.llm.providers import ProviderError
@@ -540,7 +596,10 @@ async def test_tool_round_limit_rolls_back_current_question(app: App, mock_model
         finish_reason="tool_calls",
     )
     mocker.patch.object(plugin_config, "max_tool_rounds", 1)
-    mocker.patch("src.plugins.llm.handler.chat", side_effect=[tool_completion, tool_completion])
+    chat = mocker.patch(
+        "src.plugins.llm.handler.chat",
+        side_effect=[tool_completion, tool_completion, tool_completion],
+    )
 
     async def execute(calls, context):
         context.append(Message.tool(calls[0].id, "晴"))
@@ -549,7 +608,38 @@ async def test_tool_round_limit_rolls_back_current_question(app: App, mock_model
     handler = LLMHandler("test-model")
     original_context = list(handler.context)
 
-    with pytest.raises(ProviderError, match="工具调用超过上限"):
+    with pytest.raises(ProviderError, match="达到上限后仍未生成最终回复"):
+        await handler.ask("天气")
+
+    assert handler.context == original_context
+    assert chat.await_args_list[-1].kwargs["enable_tools"] is False
+
+
+async def test_tool_round_limit_rolls_back_when_final_request_fails(app: App, mock_models, mocker):
+    """无工具收尾请求失败时回滚当前问题。"""
+    from src.plugins.llm.config import plugin_config
+    from src.plugins.llm.handler import LLMHandler
+    from src.plugins.llm.providers import ProviderError
+    from src.plugins.llm.schemas import Completion, Message, ToolCall
+
+    tool_completion = Completion(
+        message=Message.assistant(tool_calls=[ToolCall(id="call_1", name="get_weather", arguments={})]),
+        finish_reason="tool_calls",
+    )
+    mocker.patch.object(plugin_config, "max_tool_rounds", 1)
+    mocker.patch(
+        "src.plugins.llm.handler.chat",
+        side_effect=[tool_completion, tool_completion, ProviderError("收尾请求失败")],
+    )
+
+    async def execute(calls, context):
+        context.append(Message.tool(calls[0].id, "晴"))
+
+    mocker.patch("src.plugins.llm.handler.execute_tool_calls", side_effect=execute)
+    handler = LLMHandler("test-model")
+    original_context = list(handler.context)
+
+    with pytest.raises(ProviderError, match="收尾请求失败"):
         await handler.ask("天气")
 
     assert handler.context == original_context


### PR DESCRIPTION
## 变更内容

- 工具调用达到 `max_tool_rounds` 后，不再直接回滚并报错
- 丢弃尚未执行的工具请求，禁用工具并基于已有结果生成一次收尾回复
- 收尾请求继续计入整轮 token、模型和耗时统计；收尾失败时仍回滚不完整上下文
- 将 `max_tool_rounds` 默认值从 5 调整为 10，并同步 README 与 CHANGELOG

## 验证

- `uv run poe test`：299 passed
- `uv run pytest tests/plugins/llm -n auto`：133 passed
- `uv run --with pyright pyright src/plugins/llm/handler.py src/plugins/llm/config.py tests/plugins/llm/test_llm.py tests/plugins/llm/test_data_source.py`：0 errors
- `uv run pre-commit run --files ...`：全部通过
- `git diff --check`：通过