### PR TITLE
fix(llm): 修复 QQ 适配器处理状态提示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复 `LLM__BASE_URL` 包含 `/v1` 等 API 版本路径时，Aperture 与 DeepSeek 额度接口地址解析错误的问题
+- 修复 QQ 适配器不支持 reaction 时缺少大模型开始处理提示的问题，改为发送普通消息反馈
 
 ## [0.29.1] - 2026-08-04
 

--- a/src/plugins/llm/README.md
+++ b/src/plugins/llm/README.md
@@ -22,7 +22,7 @@
 - 群聊中直接 @ 机器人即可使用默认模型对话
 - 流式与非流式请求
 - 推理内容以引用块展示（DeepSeek 的 `reasoning_content`、Anthropic 的 `thinking`、Responses 的推理摘要）
-- 使用 emoji reaction 反馈响应状态（思考中、已完成、失败；不支持的平台自动跳过）
+- 使用 emoji reaction 反馈响应状态（思考中、已完成、失败）；QQ 适配器开始处理时改发普通消息，其他不支持的平台自动跳过
 - `/chat` 提供不发送工具定义的纯对话，`/agent` 默认开放全部已注册工具
 - 工具调用（function calling）适配三种 API 格式；耗时较长时定期提示模型请求与工具调用进度
 - 默认提供最终幻想 XIV 国服物价、时尚品鉴和 FFLogs 角色排名查询工具

--- a/src/plugins/llm/handler.py
+++ b/src/plugins/llm/handler.py
@@ -42,7 +42,10 @@ REACTION_EMOJIS: dict[ReactionStatus, tuple[str, str]] = {
     "thinking": ("424", "👀"),
     "done": ("144", "🎉"),
 }
-"""QQ emoji ID 与其他平台 Unicode emoji 的对应关系"""
+"""OneBot V11 emoji ID 与其他平台 Unicode emoji 的对应关系"""
+
+QQ_THINKING_NOTICE = "👀 已收到，正在处理……"
+"""QQ 适配器不支持 reaction，开始处理时改发普通消息。"""
 
 
 @dataclass
@@ -126,17 +129,22 @@ async def send_reaction(
     *,
     message_id: str | None = None,
 ) -> None:
-    """给触发消息添加响应状态；平台不支持或调用失败时静默跳过"""
+    """反馈响应状态；QQ 开始处理时发消息，其余平台优先使用 reaction。"""
     try:
         target = get_target()
-        is_qq = target.adapter in (SupportAdapter.onebot11, SupportAdapter.qq)
-        if is_qq and target.private:
+        if target.adapter == SupportAdapter.qq:
+            if status == "thinking":
+                await UniMessage.text(QQ_THINKING_NOTICE).send(reply_to=message_id or True)
             return
 
-        emoji = REACTION_EMOJIS[status][0 if is_qq else 1]
+        is_onebot = target.adapter == SupportAdapter.onebot11
+        if is_onebot and target.private:
+            return
+
+        emoji = REACTION_EMOJIS[status][0 if is_onebot else 1]
         await message_reaction(emoji, message_id=message_id)
     except Exception as e:
-        logger.opt(exception=e).debug("添加大模型响应状态失败，已忽略")
+        logger.opt(exception=e).debug("发送大模型响应状态失败，已忽略")
 
 
 async def execute_tool_calls(

--- a/tests/plugins/llm/test_data_source.py
+++ b/tests/plugins/llm/test_data_source.py
@@ -562,7 +562,7 @@ def test_format_statistics_splits_model_chain(app: App):
     ],
 )
 async def test_send_reaction_uses_adapter_emoji(app: App, mocker, adapter, status, expected):
-    """QQ 使用 emoji ID，其他平台使用 Unicode emoji"""
+    """OneBot V11 使用 emoji ID，其他支持的平台使用 Unicode emoji"""
     from src.plugins.llm.handler import send_reaction
 
     get_target = mocker.patch(
@@ -577,8 +577,54 @@ async def test_send_reaction_uses_adapter_emoji(app: App, mocker, adapter, statu
     reaction.assert_awaited_once_with(expected, message_id="42")
 
 
+@pytest.mark.parametrize(
+    ("message_id", "expected_reply"),
+    [(None, True), ("42", "42")],
+)
+async def test_send_reaction_sends_qq_thinking_notice(app: App, mocker, message_id, expected_reply):
+    """QQ 适配器不支持 reaction，开始处理时改发普通消息。"""
+    from nonebot_plugin_alconna import SupportAdapter
+
+    from src.plugins.llm.handler import QQ_THINKING_NOTICE, send_reaction
+
+    mocker.patch(
+        "src.plugins.llm.handler.get_target",
+        return_value=SimpleNamespace(adapter=SupportAdapter.qq, private=False),
+    )
+    reaction = mocker.patch("src.plugins.llm.handler.message_reaction")
+    message = mocker.Mock()
+    message.send = mocker.AsyncMock()
+    text = mocker.patch("src.plugins.llm.handler.UniMessage.text", return_value=message)
+
+    await send_reaction("thinking", message_id=message_id)
+
+    text.assert_called_once_with(QQ_THINKING_NOTICE)
+    message.send.assert_awaited_once_with(reply_to=expected_reply)
+    reaction.assert_not_awaited()
+
+
+@pytest.mark.parametrize("status", ["done", "fail"])
+async def test_send_reaction_skips_qq_terminal_status(app: App, mocker, status):
+    """QQ 普通消息只提示开始处理，完成和失败仍由最终回复说明。"""
+    from nonebot_plugin_alconna import SupportAdapter
+
+    from src.plugins.llm.handler import send_reaction
+
+    mocker.patch(
+        "src.plugins.llm.handler.get_target",
+        return_value=SimpleNamespace(adapter=SupportAdapter.qq, private=False),
+    )
+    reaction = mocker.patch("src.plugins.llm.handler.message_reaction")
+    text = mocker.patch("src.plugins.llm.handler.UniMessage.text")
+
+    await send_reaction(status, message_id="42")
+
+    text.assert_not_called()
+    reaction.assert_not_awaited()
+
+
 async def test_send_reaction_skips_qq_private_message(app: App, mocker):
-    """QQ 私聊不支持消息 reaction，直接跳过"""
+    """OneBot V11 私聊不支持消息 reaction，直接跳过"""
     from nonebot_plugin_alconna import SupportAdapter
 
     from src.plugins.llm.handler import send_reaction


### PR DESCRIPTION
## 概要

- QQ 适配器开始处理大模型请求时，发送“👀 已收到，正在处理……”普通消息
- QQ 适配器在完成或失败阶段不再尝试发送不受支持的 reaction
- 保留 OneBot V11 数字 emoji reaction 与其他平台 Unicode reaction 行为
- 同步 LLM 文档、CHANGELOG 和行为测试

## 测试

- `uv run pytest tests/plugins/llm/test_data_source.py -q -k send_reaction`（8 passed）
- `uv run pytest -n auto tests/plugins/llm -q`（191 passed）
- `uv run ruff check src/plugins/llm/handler.py tests/plugins/llm/test_data_source.py`
- `uv run ruff format --check src/plugins/llm/handler.py tests/plugins/llm/test_data_source.py`
- 提交钩子：Ruff、Ruff Format、Prettier 均通过