### PR TITLE
fix(llm): 正确处理回复消息上下文

### DIFF
--- a/src/plugins/llm/__init__.py
+++ b/src/plugins/llm/__init__.py
@@ -5,30 +5,30 @@ API 格式，提供多轮对话、推理内容展示、原生 Markdown、Markdow
 额度查询按模型选择独立 provider，目前支持 Aperture 与 DeepSeek。
 """
 
-from dataclasses import dataclass
 from pathlib import Path
 
 import nonebot
-from nonebot import on_message, require
+from nonebot import require
 from nonebot.adapters import Bot, Event
 from nonebot.log import logger
 from nonebot.matcher import Matcher
+from nonebot.permission import MESSAGE
 from nonebot.plugin import PluginMetadata, inherit_supported_adapters
-from nonebot.rule import Rule, to_me
 from nonebot.typing import T_State
 
 require("nonebot_plugin_orm")
 require("nonebot_plugin_user")
 require("nonebot_plugin_waiter")
 require("nonebot_plugin_alconna")
-from arclet.alconna import store_true
+from arclet.alconna import AllParam, store_true
 from nonebot_plugin_alconna import (
     Alconna,
-    AlconnaMatch,
     Args,
     CommandMeta,
+    Extension,
     Image,
     Match,
+    MsgId,
     MultiVar,
     Option,
     Query,
@@ -38,7 +38,7 @@ from nonebot_plugin_alconna import (
     image_fetch,
     on_alconna,
 )
-from nonebot_plugin_alconna.builtins.extensions.reply import ReplyMergeExtension
+from nonebot_plugin_alconna.builtins.extensions.reply import ReplyRecordExtension
 from nonebot_plugin_alconna.builtins.extensions.telegram import TelegramSlashExtension
 from nonebot_plugin_user import UserSession
 
@@ -64,7 +64,7 @@ from .data_source import (
 from .handler import LLMHandler, send_reaction
 from .providers import ProviderError
 from .quota import QuotaError, get_quota, get_quotas
-from .rules import is_non_private
+from .rules import MENTION_RULE, NON_PRIVATE_RULE
 from .schemas import ImageContent
 from .tts import TTSError, get_tts_models
 
@@ -125,7 +125,8 @@ llm_cmd = on_alconna(
     ),
     use_cmd_start=True,
     block=True,
-    rule=Rule(is_non_private),
+    rule=NON_PRIVATE_RULE,
+    permission=MESSAGE,
     extensions=[
         TelegramSlashExtension(),
     ],
@@ -134,7 +135,7 @@ llm_cmd = on_alconna(
 
 chat_command = Alconna(
     "chat",
-    Args["content?#内容", MultiVar(str, flag="+")]["img?#图片", Image],
+    Args["content?#内容", AllParam],
     Option("--model", Args["model#模型名称", str], help_text="本次使用指定模型"),
     Option("-c|--context", default=False, action=store_true, help_text="启用多轮对话"),
     Option("-r|--render", default=False, action=store_true, help_text="渲染 Markdown 为图片"),
@@ -150,9 +151,10 @@ chat_cmd = on_alconna(
     chat_command,
     use_cmd_start=True,
     block=True,
-    rule=Rule(is_non_private),
+    rule=NON_PRIVATE_RULE,
+    permission=MESSAGE,
     extensions=[
-        ReplyMergeExtension(),
+        ReplyRecordExtension(),
         TelegramSlashExtension(),
     ],
 )
@@ -162,18 +164,49 @@ llm_cmd.shortcut("quota", command="llm quota", prefix=True, fuzzy=True, humanize
 llm_cmd.shortcut("额度", command="llm quota", prefix=True, fuzzy=True, humanized="额度 [模型名|--all]")
 
 
-async def _should_handle_mention(event: Event) -> bool:
-    """按配置启用快捷对话，并避免带非空前缀的命令被重复处理。"""
-    if not plugin_config.respond_to_mention:
-        return False
-    text = event.get_plaintext().lstrip()
-    return not any(prefix and text.startswith(prefix) for prefix in nonebot.get_driver().config.command_start)
+class MentionChatExtension(Extension):
+    """为 @ 对话补上 chat 命令头，让消息交由 Alconna 正常解析。"""
+
+    @property
+    def priority(self) -> int:
+        return 15
+
+    @property
+    def id(self) -> str:
+        return "coolqbot.llm:mention_chat"
+
+    async def message_provider(
+        self,
+        event: Event,
+        state: T_State,
+        bot: Bot,
+        use_origin: bool = False,
+    ) -> UniMessage | None:
+        """为空的纯回复提供占位消息，使其仍能进入命令包装与回复记录流程。"""
+        try:
+            if event.get_message():
+                return None
+        except (NotImplementedError, ValueError):
+            return None
+        return UniMessage.text(" ")
+
+    async def receive_wrapper(self, bot: Bot, event: Event, command: Alconna, receive: UniMessage) -> UniMessage:
+        command_prefix = command.prefixes[0] if command.prefixes else ""
+        message = UniMessage.text(f"{command_prefix}{command.command} ")
+        message.extend(receive)
+        return message
 
 
-llm_mention = on_message(
-    rule=Rule(is_non_private) & to_me() & Rule(_should_handle_mention),
+llm_mention = on_alconna(
+    chat_command,
+    rule=MENTION_RULE,
+    permission=MESSAGE,
     priority=15,
     block=True,
+    extensions=[
+        ReplyRecordExtension(),
+        MentionChatExtension(),
+    ],
 )
 
 
@@ -183,34 +216,6 @@ class LLMSetupError(ValueError):
     def __init__(self, message: str, *, at_sender: bool = False) -> None:
         super().__init__(message)
         self.at_sender = at_sender
-
-
-@dataclass(frozen=True)
-class ChatRequest:
-    """统一后的对话文本与选项。"""
-
-    text: str
-    model_name: str
-    use_context: bool
-    render: bool
-    use_tts: bool
-    enable_tools: bool
-
-
-def _parse_mention_text(text: str) -> ChatRequest:
-    """复用 /chat 的 Alconna 定义解析 @ 对话参数。"""
-    result = chat_command.parse(f"/chat {text}".rstrip())
-    if not result.matched:
-        raise LLMSetupError("对话参数有误，请输入 /chat -h 查看用法", at_sender=True)
-    content: tuple[str, ...] = result.query("content", ())
-    return ChatRequest(
-        text=" ".join(content),
-        model_name=result.query("model.model", ""),
-        use_context=result.query("context.value", False),
-        render=result.query("render.value", False),
-        use_tts=result.query("tts.value", False),
-        enable_tools=result.query("agent.value", False),
-    )
 
 
 async def _create_handler(
@@ -519,11 +524,101 @@ async def llm_quota_handle(
     await llm_cmd.finish(result, at_sender=True)
 
 
+async def _extract_dialogue_content(
+    content: Match[UniMessage],
+    msg_id: MsgId,
+    ext: ReplyRecordExtension,
+    bot: Bot,
+    event: Event,
+    state: T_State,
+) -> tuple[str, list[ImageContent] | None]:
+    """分别提取当前消息与被回复消息，并编码其回复关系。"""
+    current_message = content.result if content.available else UniMessage()
+    reply_message = UniMessage()
+    reply = ext.get_reply(msg_id)
+    has_reply = reply is not None
+    if reply is not None:
+        if not reply.msg:
+            raise ValueError("上一条消息内容为空")
+        raw_reply_message = reply.msg
+        if isinstance(raw_reply_message, str):
+            raw_reply_message = event.get_message().__class__(raw_reply_message)
+        reply_message = UniMessage.of(raw_reply_message, bot=bot)
+
+    current_text = current_message.extract_plain_text().strip()
+    replied_text = reply_message.extract_plain_text().strip()
+    current_images = current_message.get(Image)
+    replied_images = reply_message.get(Image)
+    images = await _fetch_message_images([*current_images, *replied_images], event, bot, state)
+
+    if has_reply and not current_text and not current_images:
+        return replied_text, images or None
+    if has_reply:
+        text = _format_reply_context(
+            current_text,
+            replied_text,
+            current_image_count=len(current_images),
+            replied_image_count=len(replied_images),
+        )
+    else:
+        text = current_text
+    return text, images or None
+
+
+def _format_reply_context(
+    current_text: str,
+    replied_text: str,
+    *,
+    current_image_count: int,
+    replied_image_count: int,
+) -> str:
+    """明确标记回复目标与当前请求，避免模型把结构本身当成待处理数据。"""
+    parts = [
+        "【用户正在回复或引用的消息】",
+        replied_text or "（无文字）",
+        "",
+        "【用户本次发送的消息】",
+        current_text or "（无文字）",
+    ]
+    if current_image_count or replied_image_count:
+        parts.extend(["", "【图片归属】"])
+        if current_image_count and replied_image_count:
+            parts.append(
+                f"随请求提供的前 {current_image_count} 张图片属于用户本次发送的消息，"
+                f"后 {replied_image_count} 张属于用户正在回复或引用的消息。"
+            )
+        elif current_image_count:
+            parts.append(f"随请求提供的 {current_image_count} 张图片均属于用户本次发送的消息。")
+        else:
+            parts.append(f"随请求提供的 {replied_image_count} 张图片均属于用户正在回复或引用的消息。")
+    return "\n".join(parts)
+
+
+async def _fetch_message_images(
+    image_segments: list[Image],
+    event: Event,
+    bot: Bot,
+    state: T_State,
+) -> list[ImageContent]:
+    """读取一条消息中的全部图片。"""
+    images: list[ImageContent] = []
+    for image in image_segments:
+        data = await image_fetch(event, bot, state, image)
+        if not data:
+            raise ValueError("图片读取失败")
+        images.append(ImageContent.from_bytes(data))
+    return images
+
+
 async def _handle_dialogue_command(
     matcher: type[Matcher],
+    bot: Bot,
+    event: Event,
+    state: T_State,
+    msg_id: MsgId,
+    ext: ReplyRecordExtension,
     user: UserSession,
-    content: Match[tuple[str, ...]],
-    img: Match[bytes],
+    content: Match[UniMessage],
     model_name: Query[str],
     use_context: Query[bool],
     render: Query[bool],
@@ -532,17 +627,14 @@ async def _handle_dialogue_command(
     enable_tools: bool,
 ) -> None:
     """执行共享的纯对话或工具增强命令流程。"""
-    if not content.available and not img.available:
+    try:
+        text, images = await _extract_dialogue_content(content, msg_id, ext, bot, event, state)
+    except ValueError as e:
+        await matcher.finish(str(e), at_sender=True)
+
+    if not text and not images:
         command_name = "agent" if enable_tools else "chat"
         await matcher.finish(f"你想问什么呢？输入 /{command_name} -h 查看用法", at_sender=True)
-
-    images: list[ImageContent] | None = None
-    if img.available:
-        try:
-            images = [ImageContent.from_bytes(img.result)]
-        except ValueError as e:
-            await matcher.finish(str(e), at_sender=True)
-    text = " ".join(content.result) if content.available else ""
 
     try:
         handler = await _create_handler(
@@ -567,9 +659,13 @@ async def _handle_dialogue_command(
 
 @chat_cmd.handle()
 async def chat_handle(
+    bot: Bot,
+    event: Event,
+    state: T_State,
+    msg_id: MsgId,
+    ext: ReplyRecordExtension,
     user: UserSession,
-    content: Match[tuple[str, ...]],
-    img: Match[bytes] = AlconnaMatch("img", image_fetch),
+    content: Match[UniMessage],
     model_name: Query[str] = Query("model.model"),
     use_context: Query[bool] = Query("context.value", False),
     render: Query[bool] = Query("render.value", False),
@@ -578,9 +674,13 @@ async def chat_handle(
 ) -> None:
     await _handle_dialogue_command(
         chat_cmd,
+        bot,
+        event,
+        state,
+        msg_id,
+        ext,
         user,
         content,
-        img,
         model_name,
         use_context,
         render,
@@ -594,45 +694,40 @@ async def llm_mention_handle(
     bot: Bot,
     event: Event,
     state: T_State,
+    msg_id: MsgId,
+    ext: ReplyRecordExtension,
     user: UserSession,
+    content: Match[UniMessage],
+    model_name: Query[str] = Query("model.model"),
+    use_context: Query[bool] = Query("context.value", False),
+    render: Query[bool] = Query("render.value", False),
+    use_tts: Query[bool] = Query("tts.value", False),
+    use_agent: Query[bool] = Query("agent.value", False),
 ) -> None:
-    """把群聊中 @ 机器人的内容直接交给默认模型。"""
-    message_id = get_message_id(event)
-    message = UniMessage.of(event.get_message(), bot=bot)
-    text = message.extract_plain_text().strip()
-    images: list[ImageContent] = []
+    """把群聊中 @ 机器人的 Alconna 解析结果交给对话流程。"""
     try:
-        for image in message.get(Image):
-            data = await image_fetch(event, bot, state, image)
-            if not data:
-                raise ValueError("图片读取失败")
-            images.append(ImageContent.from_bytes(data))
+        text, images = await _extract_dialogue_content(content, msg_id, ext, bot, event, state)
     except ValueError as e:
-        await UniMessage.text(str(e)).finish(reply_to=message_id)
+        await UniMessage.text(str(e)).finish(reply_to=msg_id)
 
-    try:
-        request = _parse_mention_text(text)
-    except LLMSetupError as e:
-        await UniMessage.text(str(e)).finish(at_sender=e.at_sender, reply_to=message_id)
-
-    if not request.text and not images:
-        await UniMessage.text("你想问什么呢？").finish(reply_to=message_id)
+    if not text and not images:
+        await UniMessage.text("你想问什么呢？").finish(reply_to=msg_id)
 
     try:
         handler = await _create_handler(
             user,
-            selected_model=request.model_name,
-            render=request.render,
-            use_tts=request.use_tts,
-            enable_tools=request.enable_tools,
+            selected_model=model_name.result if model_name.available else "",
+            render=render.result,
+            use_tts=use_tts.result,
+            enable_tools=use_agent.result,
         )
     except LLMSetupError as e:
-        await UniMessage.text(str(e)).finish(at_sender=e.at_sender, reply_to=message_id)
-    if request.use_context:
-        await _handle_with_context(handler, request.text, images or None, message_id=message_id)
+        await UniMessage.text(str(e)).finish(at_sender=e.at_sender, reply_to=msg_id)
+    if use_context.result:
+        await _handle_with_context(handler, text, images, message_id=msg_id)
         return
-    completion = await _ask(handler, request.text, images or None, message_id=message_id)
-    await handler.send(completion, reply_to=message_id)
+    completion = await _ask(handler, text, images, message_id=msg_id)
+    await handler.send(completion, reply_to=msg_id)
 
 
 async def _handle_with_context(
@@ -664,7 +759,7 @@ async def _handle_with_context(
         )
         if received is None:
             await UniMessage.text("等待超时，已结束对话").finish()
-        reply, reply_message_id = received
+        reply, reply_message_id, reply_event, reply_bot, reply_state = received
 
         message = reply.extract_plain_text().strip()
         if message in ("结束", "取消"):
@@ -675,22 +770,27 @@ async def _handle_with_context(
             else:
                 await UniMessage.text("当前没有可回滚的对话").send()
             continue
-        if not message:
+        try:
+            reply_images = await _fetch_message_images(reply.get(Image), reply_event, reply_bot, reply_state)
+        except ValueError as e:
+            await finish_matcher.finish(str(e), at_sender=True)
+        if not message and not reply_images:
             continue
 
         completion = await _ask(
             handler,
             message,
-            None,
+            reply_images or None,
             message_id=reply_message_id,
             finish_matcher=finish_matcher,
         )
         await handler.send(completion)
 
 
-def _extract_reply(reply_event: Event):
-    """提取续聊消息，并在 waiter 事件上下文中保存其消息 ID"""
-    return reply_event.get_message(), get_message_id(reply_event)
+def _extract_reply(reply_event: Event, bot: Bot, state: T_State):
+    """提取续聊消息及下载其中媒体所需的事件上下文。"""
+    message = UniMessage.of(reply_event.get_message(), bot=bot)
+    return message, get_message_id(reply_event), reply_event, bot, state
 
 
 async def _send_request_wait_notice(

--- a/src/plugins/llm/plugins/zssm/__init__.py
+++ b/src/plugins/llm/plugins/zssm/__init__.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from arclet.alconna import AllParam, store_true
 from nonebot.adapters import Bot, Event
 from nonebot.log import logger
+from nonebot.permission import MESSAGE
 from nonebot.plugin import PluginMetadata, inherit_supported_adapters
-from nonebot.rule import Rule
 from nonebot.typing import T_State
 from nonebot_plugin_alconna import Alconna, Args, CommandMeta, Match, MsgId, Option, Query, UniMessage, on_alconna
 from nonebot_plugin_alconna.builtins.extensions.reply import ReplyRecordExtension
@@ -21,7 +21,7 @@ from ...data_source import (
 )
 from ...handler import LLMHandler, send_reaction, split_content
 from ...providers import ProviderError
-from ...rules import is_non_private
+from ...rules import NON_PRIVATE_RULE
 from .data_source import (
     build_user_prompt,
     describe_images,
@@ -52,7 +52,8 @@ zssm_cmd = on_alconna(
         ),
     ),
     block=True,
-    rule=Rule(is_non_private),
+    rule=NON_PRIVATE_RULE,
+    permission=MESSAGE,
     extensions=[ReplyRecordExtension()],
 )
 

--- a/src/plugins/llm/rules.py
+++ b/src/plugins/llm/rules.py
@@ -1,8 +1,36 @@
 """大模型入口的共用匹配规则。"""
 
-from nonebot_plugin_user import UserSession
+import nonebot
+from nonebot.adapters import Bot, Event
+from nonebot.rule import Rule, to_me
+from nonebot.typing import T_State
+from nonebot_plugin_uninfo import Uninfo
+
+from .config import plugin_config
 
 
-async def is_non_private(user: UserSession) -> bool:
+async def is_non_private(session: Uninfo) -> bool:
     """拒绝私聊，允许群聊、频道和子频道事件。"""
-    return not user.session.scene.is_private
+    return not session.scene.is_private
+
+
+NON_PRIVATE_RULE = Rule(is_non_private)
+_TO_ME_RULE = to_me()
+
+
+async def should_handle_mention(bot: Bot, event: Event, state: T_State) -> bool:
+    """按配置启用快捷对话，并避免带非空前缀的命令被重复处理。"""
+    if not plugin_config.respond_to_mention or event.get_type() != "message":
+        return False
+    if not await _TO_ME_RULE(bot, event, state):
+        return False
+    try:
+        text = event.get_plaintext().lstrip()
+    except (NotImplementedError, ValueError):
+        return False
+    if any(prefix and text.startswith(prefix) for prefix in nonebot.get_driver().config.command_start):
+        return False
+    return await NON_PRIVATE_RULE(bot, event, state)
+
+
+MENTION_RULE = Rule(should_handle_mention)

--- a/tests/plugins/llm/test_llm.py
+++ b/tests/plugins/llm/test_llm.py
@@ -41,24 +41,66 @@ def test_dialogue_command_is_separate_from_management(app: App):
 
     result = chat_command.parse("/chat model tts quota")
     assert result.matched
-    assert result.query("content") == ("model", "tts", "quota")
+    assert result.query("content").extract_plain_text() == "model tts quota"
     result = chat_command.parse("/chat -a model tts quota")
     assert result.matched
     assert result.query("agent.value") is True
-    assert result.query("content") == ("model", "tts", "quota")
+    assert result.query("content").extract_plain_text() == "model tts quota"
     assert not llm_cmd.command().parse("/llm 你好").matched
 
 
 @pytest.mark.parametrize("flag", ["-s", "--search"])
 def test_removed_search_flags_are_plain_dialogue_content(app: App, flag: str):
     """已移除的搜索参数不再保留特殊语义。"""
-    from src.plugins.llm import _parse_mention_text, chat_command
+    from src.plugins.llm import chat_command
 
     result = chat_command.parse(f"/chat {flag} 查询")
 
     assert result.matched
-    assert result.query("content") == (flag, "查询")
-    assert _parse_mention_text(f"{flag} 查询").text == f"{flag} 查询"
+    assert result.query("content").extract_plain_text() == f"{flag} 查询"
+
+
+@pytest.mark.parametrize(
+    ("current_count", "replied_count", "expected"),
+    [
+        (1, 0, "随请求提供的 1 张图片均属于用户本次发送的消息。"),
+        (1, 2, "随请求提供的前 1 张图片属于用户本次发送的消息，后 2 张属于用户正在回复或引用的消息。"),
+    ],
+)
+def test_reply_context_describes_image_ownership(
+    app: App,
+    current_count: int,
+    replied_count: int,
+    expected: str,
+):
+    """图片归属说明覆盖当前消息独有及双方均有图片的情况。"""
+    from src.plugins.llm import _format_reply_context
+
+    result = _format_reply_context(
+        "当前消息",
+        "原消息",
+        current_image_count=current_count,
+        replied_image_count=replied_count,
+    )
+
+    assert result.endswith(expected)
+
+
+def test_reply_context_defines_reply_target_without_negative_constraints(app: App):
+    """自指问题使用明确的回复对象关系，不再加入诱发元分析的否定指令。"""
+    from src.plugins.llm import _format_reply_context
+
+    result = _format_reply_context(
+        "我回复了什么？",
+        "你好",
+        current_image_count=0,
+        replied_image_count=0,
+    )
+
+    assert result.startswith("【用户正在回复或引用的消息】\n你好")
+    assert "【用户本次发送的消息】\n我回复了什么？" in result
+    assert "不要" not in result
+    assert "请" not in result
 
 
 def test_session_affinity_is_per_conversation(app: App, mock_models):
@@ -74,16 +116,20 @@ def test_session_affinity_is_per_conversation(app: App, mock_models):
 
 
 def test_extract_context_reply_keeps_message_id(app: App, mocker):
-    """续聊消息在 waiter 的事件上下文中保存消息 ID"""
+    """续聊消息保留消息 ID 与下载图片所需的事件上下文。"""
     from src.plugins.llm import _extract_reply
 
     event = fake_group_message_event_v11(message=Message("继续聊"), message_id=42)
+    bot = mocker.Mock()
+    state = {}
+    message = mocker.Mock()
+    message_of = mocker.patch("src.plugins.llm.UniMessage.of", return_value=message)
     get_message_id = mocker.patch("src.plugins.llm.get_message_id", return_value="42")
 
-    message, message_id = _extract_reply(event)
+    result = _extract_reply(event, bot, state)
 
-    assert message == event.get_message()
-    assert message_id == "42"
+    assert result == (message, "42", event, bot, state)
+    message_of.assert_called_once_with(event.get_message(), bot=bot)
     get_message_id.assert_called_once_with(event)
 
 
@@ -103,7 +149,13 @@ async def test_context_reply_reacts_to_current_message(app: App, mocker):
     )
     mocker.patch(
         "nonebot_plugin_waiter.prompt",
-        return_value=(Message("继续聊"), "42"),
+        return_value=(
+            mocker.Mock(extract_plain_text=mocker.Mock(return_value="继续聊"), get=mocker.Mock(return_value=[])),
+            "42",
+            mocker.Mock(),
+            mocker.Mock(),
+            {},
+        ),
     )
 
     with pytest.raises(StopConversation):
@@ -113,6 +165,44 @@ async def test_context_reply_reacts_to_current_message(app: App, mocker):
         call(handler, "开始", None, finish_matcher=chat_cmd),
         call(handler, "继续聊", None, message_id="42", finish_matcher=chat_cmd),
     ]
+    handler.send.assert_awaited_once_with(first_completion)
+
+
+@pytest.mark.parametrize("reply_text", ["", "继续聊"])
+async def test_context_reply_supports_images(app: App, mocker, reply_text: str):
+    """多轮续聊保留仅图片和图文混合消息中的图片。"""
+    from nonebot_plugin_alconna import Image, UniMessage
+
+    from src.plugins.llm import _handle_with_context, chat_cmd
+
+    class StopConversation(Exception):
+        pass
+
+    png = b"\x89PNG\r\n\x1a\n" + b"test"
+    reply = UniMessage.text(reply_text) + Image(raw=png)
+    reply_event = mocker.Mock()
+    reply_bot = mocker.Mock()
+    reply_state = {}
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    first_completion = object()
+    ask = mocker.patch("src.plugins.llm._ask", side_effect=[first_completion, StopConversation])
+    mocker.patch(
+        "nonebot_plugin_waiter.prompt",
+        return_value=(reply, "42", reply_event, reply_bot, reply_state),
+    )
+    image_fetch = mocker.patch("src.plugins.llm.image_fetch", return_value=png)
+
+    with pytest.raises(StopConversation):
+        await _handle_with_context(handler, "开始", None)
+
+    assert ask.await_args_list[0] == call(handler, "开始", None, finish_matcher=chat_cmd)
+    assert ask.await_args_list[1].args[:2] == (handler, reply_text)
+    images = ask.await_args_list[1].args[2]
+    assert len(images) == 1
+    assert images[0].data == png
+    assert ask.await_args_list[1].kwargs == {"message_id": "42", "finish_matcher": chat_cmd}
+    image_fetch.assert_awaited_once_with(reply_event, reply_bot, reply_state, reply.get(Image)[0])
     handler.send.assert_awaited_once_with(first_completion)
 
 
@@ -241,6 +331,155 @@ async def test_chat_agent_option_and_shortcut_enable_all_tools(
     } <= tool_names
 
 
+@pytest.mark.parametrize(
+    ("message", "enable_tools"),
+    [("/chat 这句话什么意思？", False), ("/agent 这句话什么意思？", True)],
+)
+async def test_chat_and_agent_share_structured_reply_context(
+    app: App,
+    mock_models,
+    mocker,
+    message: str,
+    enable_tools: bool,
+):
+    """/chat 与 /agent 都分别保留当前消息、被回复消息及图片归属。"""
+    from nonebot.adapters.onebot.v11 import MessageSegment
+    from nonebot.adapters.onebot.v11.event import Reply, Sender
+
+    from src.plugins.llm import chat_cmd
+
+    png = b"\x89PNG\r\n\x1a\n" + b"test"
+    reply = Reply(
+        time=1,
+        message_type="group",
+        message_id=99,
+        real_id=99,
+        sender=Sender(user_id=20, nickname="群友"),
+        message=Message("测试协议啊") + MessageSegment.image(png),
+    )
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    completion = object()
+    create_handler = mocker.patch("src.plugins.llm._create_handler", return_value=handler)
+    ask = mocker.patch("src.plugins.llm._ask", return_value=completion)
+    fetch_image = mocker.patch("src.plugins.llm.image_fetch", return_value=png)
+
+    async with app.test_matcher(chat_cmd) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="123456")
+        event = fake_group_message_event_v11(
+            self_id=123456,
+            message_id=42,
+            message=Message(message),
+            reply=reply,
+        )
+
+        ctx.receive_event(bot, event)
+
+    create_handler.assert_awaited_once_with(
+        mocker.ANY,
+        selected_model="",
+        render=False,
+        use_tts=False,
+        enable_tools=enable_tools,
+    )
+    ask.assert_awaited_once()
+    assert ask.await_args.args[0] is handler
+    assert ask.await_args.args[1] == (
+        "【用户正在回复或引用的消息】\n测试协议啊\n\n"
+        "【用户本次发送的消息】\n这句话什么意思？\n\n"
+        "【图片归属】\n随请求提供的 1 张图片均属于用户正在回复或引用的消息。"
+    )
+    images = ask.await_args.args[2]
+    assert len(images) == 1
+    assert images[0].data == png
+    assert ask.await_args.kwargs == {"finish_matcher": chat_cmd}
+    fetch_image.assert_awaited_once()
+    handler.send.assert_awaited_once_with(completion)
+
+
+async def test_chat_reports_reply_without_content(app: App, mock_models):
+    """存在回复关系但平台未提供原消息时给出明确提示。"""
+    from nonebot.adapters.onebot.v11.event import Reply, Sender
+
+    from src.plugins.llm import chat_cmd
+
+    reply = Reply(
+        time=1,
+        message_type="group",
+        message_id=99,
+        real_id=99,
+        sender=Sender(user_id=20, nickname="群友"),
+        message=Message(),
+    )
+    async with app.test_matcher(chat_cmd) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="123456")
+        event = fake_group_message_event_v11(
+            self_id=123456,
+            message_id=42,
+            message=Message("/chat 这句话什么意思？"),
+            reply=reply,
+        )
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "上一条消息内容为空", True, at_sender=True)
+        ctx.should_finished(chat_cmd)
+
+
+@pytest.mark.parametrize(
+    ("message", "enable_tools"),
+    [("/chat", False), ("/agent", True)],
+)
+async def test_chat_reply_without_supplement_uses_replied_message_as_request(
+    app: App,
+    mock_models,
+    mocker,
+    message: str,
+    enable_tools: bool,
+):
+    """只回复并发送命令时，直接把被回复内容作为实际请求。"""
+    from nonebot.adapters.onebot.v11.event import Reply, Sender
+
+    from src.plugins.llm import chat_cmd
+
+    reply = Reply(
+        time=1,
+        message_type="group",
+        message_id=99,
+        real_id=99,
+        sender=Sender(user_id=20, nickname="群友"),
+        message=Message("测试协议啊"),
+    )
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    completion = object()
+    create_handler = mocker.patch("src.plugins.llm._create_handler", return_value=handler)
+    ask = mocker.patch("src.plugins.llm._ask", return_value=completion)
+
+    async with app.test_matcher(chat_cmd) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="123456")
+        event = fake_group_message_event_v11(
+            self_id=123456,
+            message_id=42,
+            message=Message(message),
+            reply=reply,
+        )
+
+        ctx.receive_event(bot, event)
+
+    create_handler.assert_awaited_once_with(
+        mocker.ANY,
+        selected_model="",
+        render=False,
+        use_tts=False,
+        enable_tools=enable_tools,
+    )
+    ask.assert_awaited_once_with(handler, "测试协议啊", None, finish_matcher=chat_cmd)
+    handler.send.assert_awaited_once_with(completion)
+
+
 async def test_llm_group_mention_uses_default_chat_flow(app: App, mock_models, mocker):
     """群聊明确 @ 机器人时复用默认模型与标准问答流程。"""
     from src.plugins.llm import llm_mention
@@ -302,6 +541,186 @@ async def test_llm_group_mention_supports_chat_options(app: App, mock_models, mo
     handle_with_context.assert_awaited_once_with(handler, "你好", None, message_id="42")
 
 
+async def test_llm_group_mention_labels_replied_text(app: App, mock_models, mocker):
+    """回复文字与当前问题使用明确标记分隔，避免模型误认为连续正文。"""
+    from nonebot.adapters.onebot.v11.event import Reply, Sender
+
+    from src.plugins.llm import llm_mention
+
+    reply = Reply(
+        time=1,
+        message_type="group",
+        message_id=99,
+        real_id=99,
+        sender=Sender(user_id=20, nickname="群友"),
+        message=Message("测试协议啊"),
+    )
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    completion = object()
+    mocker.patch("src.plugins.llm._create_handler", return_value=handler)
+    ask = mocker.patch("src.plugins.llm._ask", return_value=completion)
+
+    async with app.test_matcher(llm_mention) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="123456")
+        event = fake_group_message_event_v11(
+            self_id=123456,
+            message_id=42,
+            message=Message("这句话什么意思？"),
+            reply=reply,
+            to_me=True,
+        )
+
+        ctx.receive_event(bot, event)
+
+    ask.assert_awaited_once_with(
+        handler,
+        "【用户正在回复或引用的消息】\n测试协议啊\n\n【用户本次发送的消息】\n这句话什么意思？",
+        None,
+        message_id="42",
+    )
+    handler.send.assert_awaited_once_with(completion, reply_to="42")
+
+
+async def test_llm_group_mention_reply_without_supplement_uses_replied_message(
+    app: App,
+    mock_models,
+    mocker,
+):
+    """只回复并 @ 机器人时，被回复内容直接成为当前请求。"""
+    from nonebot.adapters.onebot.v11.event import Reply, Sender
+
+    from src.plugins.llm import llm_mention
+
+    reply = Reply(
+        time=1,
+        message_type="group",
+        message_id=99,
+        real_id=99,
+        sender=Sender(user_id=20, nickname="群友"),
+        message=Message("测试协议啊"),
+    )
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    completion = object()
+    mocker.patch("src.plugins.llm._create_handler", return_value=handler)
+    ask = mocker.patch("src.plugins.llm._ask", return_value=completion)
+
+    async with app.test_matcher(llm_mention) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="123456")
+        event = fake_group_message_event_v11(
+            self_id=123456,
+            message_id=42,
+            message=Message(),
+            reply=reply,
+            to_me=True,
+        )
+
+        ctx.receive_event(bot, event)
+
+    ask.assert_awaited_once_with(handler, "测试协议啊", None, message_id="42")
+    handler.send.assert_awaited_once_with(completion, reply_to="42")
+
+
+async def test_llm_group_mention_reply_only_image_uses_image_as_request(app: App, mock_models, mocker):
+    """只回复图片并 @ 机器人时，直接把该图片作为当前请求。"""
+    from nonebot.adapters.onebot.v11 import MessageSegment
+    from nonebot.adapters.onebot.v11.event import Reply, Sender
+
+    from src.plugins.llm import llm_mention
+
+    png = b"\x89PNG\r\n\x1a\n" + b"test"
+    reply = Reply(
+        time=1,
+        message_type="group",
+        message_id=99,
+        real_id=99,
+        sender=Sender(user_id=20, nickname="群友"),
+        message=Message(MessageSegment.image(png)),
+    )
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    completion = object()
+    mocker.patch("src.plugins.llm._create_handler", return_value=handler)
+    ask = mocker.patch("src.plugins.llm._ask", return_value=completion)
+    image_fetch = mocker.patch("src.plugins.llm.image_fetch", return_value=png)
+
+    async with app.test_matcher(llm_mention) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="123456")
+        event = fake_group_message_event_v11(
+            self_id=123456,
+            message_id=42,
+            message=Message(),
+            reply=reply,
+            to_me=True,
+        )
+
+        ctx.receive_event(bot, event)
+
+    ask.assert_awaited_once()
+    assert ask.await_args.args[:2] == (handler, "")
+    images = ask.await_args.args[2]
+    assert len(images) == 1
+    assert images[0].data == png
+    assert ask.await_args.kwargs == {"message_id": "42"}
+    image_fetch.assert_awaited_once()
+    handler.send.assert_awaited_once_with(completion, reply_to="42")
+
+
+async def test_llm_group_mention_merges_replied_image(app: App, mock_models, mocker):
+    """@ 对话通过 Alconna 的回复扩展读取被回复消息中的图片。"""
+    from nonebot.adapters.onebot.v11 import MessageSegment
+    from nonebot.adapters.onebot.v11.event import Reply, Sender
+
+    from src.plugins.llm import llm_mention
+
+    png = b"\x89PNG\r\n\x1a\n" + b"test"
+    reply = Reply(
+        time=1,
+        message_type="group",
+        message_id=99,
+        real_id=99,
+        sender=Sender(user_id=20, nickname="群友"),
+        message=Message(MessageSegment.image(png)),
+    )
+    handler = mocker.Mock()
+    handler.send = mocker.AsyncMock()
+    completion = object()
+    mocker.patch("src.plugins.llm._create_handler", return_value=handler)
+    ask = mocker.patch("src.plugins.llm._ask", return_value=completion)
+    fetch_image = mocker.patch("src.plugins.llm.image_fetch", return_value=png)
+
+    async with app.test_matcher(llm_mention) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, self_id="123456")
+        event = fake_group_message_event_v11(
+            self_id=123456,
+            message_id=42,
+            message=Message("请结合图片里的文字回答"),
+            reply=reply,
+            to_me=True,
+        )
+
+        ctx.receive_event(bot, event)
+
+    ask.assert_awaited_once()
+    assert ask.await_args.args[0] is handler
+    assert ask.await_args.args[1] == (
+        "【用户正在回复或引用的消息】\n（无文字）\n\n"
+        "【用户本次发送的消息】\n请结合图片里的文字回答\n\n"
+        "【图片归属】\n随请求提供的 1 张图片均属于用户正在回复或引用的消息。"
+    )
+    images = ask.await_args.args[2]
+    assert len(images) == 1
+    assert images[0].data == png
+    assert ask.await_args.kwargs == {"message_id": "42"}
+    fetch_image.assert_awaited_once()
+    handler.send.assert_awaited_once_with(completion, reply_to="42")
+
+
 async def test_create_handler_prefers_markdown_unless_render_is_explicit(app: App, mock_models, mocker):
     """全局 Markdown 偏好生效，但显式 -r 仍强制渲染图片。"""
     from src.plugins.llm import _create_handler
@@ -339,6 +758,41 @@ async def test_llm_mention_requires_to_me_message(app: App, mock_models):
 
         ctx.receive_event(bot, event)
         ctx.should_not_pass_rule(llm_mention)
+
+
+async def test_llm_mention_rule_ignores_events_without_message(app: App, mocker):
+    """Alconna matcher 收到通知等非消息事件时不应读取消息正文。"""
+    from src.plugins.llm.rules import should_handle_mention
+
+    event = mocker.Mock()
+    event.get_type.return_value = "notice"
+
+    assert await should_handle_mention(mocker.Mock(), event, {}) is False
+    event.get_plaintext.assert_not_called()
+
+
+async def test_llm_mention_rule_checks_config_before_event(app: App, mocker):
+    """关闭 @ 响应时直接短路，不再读取事件类型。"""
+    from src.plugins.llm.config import plugin_config
+    from src.plugins.llm.rules import should_handle_mention
+
+    mocker.patch.object(plugin_config, "respond_to_mention", False)
+    event = mocker.Mock()
+
+    assert await should_handle_mention(mocker.Mock(), event, {}) is False
+    event.get_type.assert_not_called()
+
+
+@pytest.mark.parametrize("matcher_name", ["llm_cmd", "chat_cmd", "llm_mention"])
+async def test_llm_entrypoints_reject_non_message_events_before_rules(app: App, mocker, matcher_name: str):
+    """所有主 LLM 入口都在执行 Alconna 与业务规则前拒绝非消息事件。"""
+    import src.plugins.llm as llm
+
+    matcher = getattr(llm, matcher_name)
+    event = mocker.Mock()
+    event.get_type.return_value = "notice"
+
+    assert await matcher.check_perm(mocker.Mock(), event) is False
 
 
 @pytest.mark.parametrize(
@@ -395,10 +849,10 @@ async def test_llm_rule_rejects_only_private_scenes(app: App, mocker, scene_type
 
     from src.plugins.llm.rules import is_non_private
 
-    user = mocker.Mock()
-    user.session.scene = Scene(id="scene", type=SceneType[scene_type])
+    session = mocker.Mock()
+    session.scene = Scene(id="scene", type=SceneType[scene_type])
 
-    assert await is_non_private(user) is expected
+    assert await is_non_private(session) is expected
 
 
 async def test_llm_mention_ignores_commands(app: App, mock_models, mocker):

--- a/tests/plugins/llm/test_zssm.py
+++ b/tests/plugins/llm/test_zssm.py
@@ -51,6 +51,16 @@ def test_zssm_has_help_metadata(app: App):
     assert "Unknown" not in help_text
 
 
+async def test_zssm_rejects_non_message_events_before_rules(app: App, mocker):
+    """zssm 与其他 LLM 入口一样先拒绝非消息事件。"""
+    from src.plugins.llm.plugins.zssm import zssm_cmd
+
+    event = mocker.Mock()
+    event.get_type.return_value = "notice"
+
+    assert await zssm_cmd.check_perm(mocker.Mock(), event) is False
+
+
 async def test_zssm_ignores_private_messages(app: App):
     """解释模式与主 LLM 入口一样不允许在私聊中使用。"""
     from src.plugins.llm.plugins.zssm import zssm_cmd


### PR DESCRIPTION
## 背景

回复文字或图片后使用 `/chat`、`/agent` 或 `@机器人` 时，原消息没有被稳定地作为回复上下文传给模型；直接合并正文或使用带任务说明的 JSON/模板也容易让模型误解消息关系。

## 改动

- 将 `@机器人` 入口改为复用 `/chat` 的 Alconna 命令与回复记录扩展，保留 `/agent` 为工具模式快捷方式
- 分别提取用户本次消息和正在回复或引用的消息，并按归属传递文字与图片
- 纯回复且没有补充内容时，直接把回复目标作为当前请求
- 使用最小化的消息分区标记回复关系，避免模型围绕包装格式进行元分析
- 多轮续聊支持纯图片及图文混合消息
- 集中 LLM 入口规则，按配置顺序检查 @ 响应，并在规则前拒绝非消息事件

## 验证

- `uv run pytest tests/plugins/llm/test_llm.py tests/plugins/llm/test_zssm.py -q`：121 passed
- `uv run ruff check src/plugins/llm/__init__.py src/plugins/llm/plugins/zssm/__init__.py src/plugins/llm/rules.py tests/plugins/llm/test_llm.py tests/plugins/llm/test_zssm.py`
- `uv run ruff format --check src/plugins/llm/__init__.py src/plugins/llm/plugins/zssm/__init__.py src/plugins/llm/rules.py tests/plugins/llm/test_llm.py tests/plugins/llm/test_zssm.py`