### PR TITLE
feat(what_to_eat): 支持远程更新美食数据并统一缓存逻辑

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 - “吃什么”插件改为从站点获取并缓存美食数据，管理员可通过 `/吃什么 update` 独立刷新并查看数据日期，无需等待机器人版本更新
 - “吃什么”标准命令遵循命令前缀并支持 Telegram、Discord Slash Command，无前缀自然语言仍通过 shortcut 响应
-- 统一节假日、美食和 FFLogs 的远程 JSON 缓存；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
+- 统一节假日、美食和 FFLogs 的远程 JSON 缓存并使用各插件的 localstore 缓存目录；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
 - 将 Wikimedia Commons 美食图片及署名许可元数据持久化到 localstore 缓存目录，避免机器人重启后重复下载
 
 ## [0.29.4] - 2026-08-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 - “吃什么”标准命令遵循命令前缀并支持 Telegram、Discord Slash Command，无前缀自然语言仍通过 shortcut 响应
 - 统一节假日、美食和 FFLogs 的远程 JSON 缓存并使用各插件的 localstore 缓存目录；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
 - 将 Wikimedia Commons 美食图片及署名许可元数据持久化到 localstore 缓存目录，避免机器人重启后重复下载
+- 调整“火锅”“串串香”“刀削面”“烤肉”“番茄炒蛋”“轻食沙拉”和“三明治”的 Wikimedia Commons 配图，并移除“自选菜”
 
 ## [0.29.4] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Changed
+
+- “吃什么”插件改为从站点获取并缓存美食数据，管理员可通过 `吃什么 update` 独立刷新，无需等待机器人版本更新
+- 统一节假日、美食和 FFLogs 的远程 JSON 缓存；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
+
 ## [0.29.4] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ### Changed
 
-- “吃什么”插件改为从站点获取并缓存美食数据，管理员可通过 `/吃什么 update` 独立刷新，无需等待机器人版本更新
+- “吃什么”插件改为从站点获取并缓存美食数据，管理员可通过 `/吃什么 update` 独立刷新并查看数据日期，无需等待机器人版本更新
 - “吃什么”标准命令遵循命令前缀并支持 Telegram、Discord Slash Command，无前缀自然语言仍通过 shortcut 响应
 - 统一节假日、美食和 FFLogs 的远程 JSON 缓存；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
 - 将 Wikimedia Commons 美食图片及署名许可元数据持久化到 localstore 缓存目录，避免机器人重启后重复下载

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 - “吃什么”插件改为从站点获取并缓存美食数据，管理员可通过 `吃什么 update` 独立刷新，无需等待机器人版本更新
 - 统一节假日、美食和 FFLogs 的远程 JSON 缓存；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
+- 将 Wikimedia Commons 美食图片及署名许可元数据持久化到 localstore 缓存目录，避免机器人重启后重复下载
 
 ## [0.29.4] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ### Changed
 
-- “吃什么”插件改为从站点获取并缓存美食数据，管理员可通过 `吃什么 update` 独立刷新，无需等待机器人版本更新
+- “吃什么”插件改为从站点获取并缓存美食数据，管理员可通过 `/吃什么 update` 独立刷新，无需等待机器人版本更新
+- “吃什么”标准命令遵循命令前缀并支持 Telegram、Discord Slash Command，无前缀自然语言仍通过 shortcut 响应
 - 统一节假日、美食和 FFLogs 的远程 JSON 缓存；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
 - 将 Wikimedia Commons 美食图片及署名许可元数据持久化到 localstore 缓存目录，避免机器人重启后重复下载
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 - “吃什么”标准命令遵循命令前缀并支持 Telegram、Discord Slash Command，无前缀自然语言仍通过 shortcut 响应
 - 统一节假日、美食和 FFLogs 的远程 JSON 缓存并使用各插件的 localstore 缓存目录；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
 - 将 Wikimedia Commons 美食图片及署名许可元数据持久化到 localstore 缓存目录，避免机器人重启后重复下载
-- 调整“火锅”“串串香”“刀削面”“烤肉”“番茄炒蛋”“轻食沙拉”和“三明治”的 Wikimedia Commons 配图，并移除“自选菜”
+- “吃什么”图片支持 Openverse 数据源，并与 Wikimedia Commons 共用署名展示和 localstore 磁盘缓存
+- 调整“火锅”“串串香”“刀削面”“烤肉”“番茄炒蛋”“轻食沙拉”和“三明治”的配图，并移除“自选菜”
 
 ## [0.29.4] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 - 统一节假日、美食和 FFLogs 的远程 JSON 缓存并使用各插件的 localstore 缓存目录；更新时会校验响应及数据、原子替换文件，并在失败时保留原缓存
 - 将 Wikimedia Commons 美食图片及署名许可元数据持久化到 localstore 缓存目录，避免机器人重启后重复下载
 - “吃什么”图片支持 Openverse 数据源，并与 Wikimedia Commons 共用署名展示和 localstore 磁盘缓存
+- “吃什么”自然语言回复会复用问题中的场景，例如“今晚吃什么”会回答“今晚吃…”
 - 调整“火锅”“串串香”“刀削面”“烤肉”“番茄炒蛋”“轻食沙拉”和“三明治”的配图，并移除“自选菜”
 
 ## [0.29.4] - 2026-08-09

--- a/public/foods.json
+++ b/public/foods.json
@@ -237,14 +237,17 @@
       "foods": [
         {
           "name": "海南鸡饭",
-          "commons_file": "File:Home-cooked Hainanese chicken rice.jpg"
+          "commons_file": "File:Hainanese chicken rice.jpg"
         },
         { "name": "越南河粉", "commons_file": "File:Bowl of Meatball pho.jpg" },
         {
           "name": "冬阴功",
           "commons_file": "File:Tom Yum Koong Soup with Prawn and Straw Mushroom.jpg"
         },
-        { "name": "咖喱鸡", "commons_file": "File:A chicken curry dish.jpg" }
+        {
+          "name": "咖喱鸡",
+          "commons_file": "File:Red Curry with Chicken - Little Thai, Brighton 2024-03-01.jpg"
+        }
       ]
     },
     {

--- a/public/foods.json
+++ b/public/foods.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": "2026-08-11",
   "categories": [
     {
       "name": "川渝风味",

--- a/public/foods.json
+++ b/public/foods.json
@@ -1,0 +1,278 @@
+{
+  "version": 1,
+  "categories": [
+    {
+      "name": "川渝风味",
+      "foods": [
+        { "name": "火锅", "commons_file": "File:Hot pot dinner.jpg" },
+        {
+          "name": "麻辣烫",
+          "commons_file": "File:Malatang from Hope Tree (20220226172344).jpg"
+        },
+        { "name": "冒菜", "commons_file": "File:传奇冒菜 1.jpg" },
+        {
+          "name": "串串香",
+          "commons_file": "File:冷锅 串 Cold-pot Skewers Y1 per skewer (1495465364).jpg"
+        },
+        {
+          "name": "酸菜鱼",
+          "commons_file": "File:酸菜鱼 Preserved Mustard Green with Fish - Charming Spice AUD24.80 (4104355401).jpg"
+        },
+        {
+          "name": "水煮肉片",
+          "commons_file": "File:Shuizhu Roupian at Daqian Restaurant, Dachenglu (20260126131330).jpg"
+        },
+        { "name": "烤鱼", "commons_file": "File:Grilled Fish with Douhua.jpg" },
+        {
+          "name": "宫保鸡丁",
+          "commons_file": "File:2016-08-14 Kung Pao Chicken dish in Beijing anagoria.jpg"
+        },
+        { "name": "鱼香肉丝", "commons_file": "File:川菜鱼香肉丝.jpg" },
+        {
+          "name": "回锅肉",
+          "commons_file": "File:Twice cooked pork, Jia Yan, 5 rue Humblot, Paris 003.jpg"
+        },
+        { "name": "口水鸡", "commons_file": "File:Koushuiji.jpg" },
+        {
+          "name": "辣子鸡",
+          "commons_file": "File:Làzijī (chicken with chilies).png"
+        },
+        { "name": "担担面", "commons_file": "File:Dandan Noodles.jpg" },
+        { "name": "麻婆豆腐", "commons_file": "File:麻婆豆腐2024.jpg" },
+        {
+          "name": "毛血旺",
+          "commons_file": "File:Chongqing-style boiled blood curd (Mao Xuewang).jpg"
+        },
+        { "name": "重庆小面", "commons_file": "File:重庆小面 - 2024-05-25.jpg" }
+      ]
+    },
+    {
+      "name": "湘鄂风味",
+      "foods": [
+        {
+          "name": "小炒肉",
+          "commons_file": "File:Lajiao Chaorou at Xiangzhongyuan Hunan Cuisine, Beijing (20240131171407).jpg"
+        },
+        {
+          "name": "剁椒鱼头",
+          "commons_file": "File:Hunan cuisine, steamed fish head in chili sauce.jpg"
+        },
+        { "name": "热干面", "commons_file": "File:Hot dry noodles.jpg" }
+      ]
+    },
+    {
+      "name": "粤港澳及客家风味",
+      "foods": [
+        {
+          "name": "白切鸡",
+          "commons_file": "File:HK SYP 西環 Sai Ying Pun 德輔道西 308 Des Voeux Road West 食神麗宮酒家 Chinese Banquet Seafood Restaurant food 海南 文昌 白切雞 Hainan Wenchang White Cut Chicken January 2026 N13P 03.jpg"
+        },
+        { "name": "烧鹅", "commons_file": "File:Cantonese roasted goose.jpg" },
+        {
+          "name": "叉烧",
+          "commons_file": "File:Char siu, West Villa Restaurant, Hong Kong - 20160221.jpg"
+        },
+        { "name": "梅菜扣肉", "commons_file": "File:11月17日 梅菜扣肉.jpg" },
+        {
+          "name": "煲仔饭",
+          "commons_file": "File:Claypot Chicken Rice, Singapore.JPG"
+        },
+        {
+          "name": "肠粉",
+          "commons_file": "File:Dried shrimp rice noodle roll.jpg"
+        },
+        {
+          "name": "炒河粉",
+          "commons_file": "File:Dry Fried Beef Ho Fun - Ho Chiak 2023-12-08.jpg"
+        },
+        { "name": "云吞面", "commons_file": "File:Wonton egg noodle soup.jpg" },
+        {
+          "name": "烧卖",
+          "commons_file": "File:HK SW 上環 Sheung Wan 星月樓 Sky Cuisine Restaurant Friday morning 早餐 breakfast steamed 燒賣 siu mai 點心 dim sum March 2026 N13P 04.jpg"
+        },
+        {
+          "name": "蛋挞",
+          "commons_file": "File:Portuguese egg tart in Macau.jpg"
+        },
+        {
+          "name": "粥",
+          "commons_file": "File:A Bowl of Congee in Tuen Mun.jpg"
+        }
+      ]
+    },
+    {
+      "name": "江浙沪风味",
+      "foods": [
+        { "name": "红烧肉", "commons_file": "File:Red braised pork belly.jpg" },
+        { "name": "东坡肉", "commons_file": "File:Dongpo pork garnished.jpg" },
+        { "name": "糖醋排骨", "commons_file": "File:糖醋排骨.JPG" },
+        {
+          "name": "小笼包",
+          "commons_file": "File:Xiao Long Bao by Junhao!.jpg"
+        },
+        { "name": "生煎包", "commons_file": "File:Shengjian mantou.jpg" },
+        { "name": "葱油拌面", "commons_file": "File:葱花葱油拌面.jpg" },
+        { "name": "馄饨", "commons_file": "File:Wonton.jpg" }
+      ]
+    },
+    {
+      "name": "华北及东北风味",
+      "foods": [
+        {
+          "name": "北京烤鸭",
+          "commons_file": "File:2016-08-27 Peking Duck at Great Wall Restaurant Beijing anagoria.jpg"
+        },
+        { "name": "炸酱面", "commons_file": "File:Zhajiangmian in Handan.jpg" },
+        { "name": "刀削面", "commons_file": "File:Datong Daoxiaomian.jpg" },
+        {
+          "name": "饺子",
+          "commons_file": "File:中国饺子（Jiaozi；Dumplings；餃子）.jpg"
+        },
+        { "name": "包子", "commons_file": "File:Baozi.JPG" },
+        { "name": "锅贴", "commons_file": "File:Potstickers RTE.jpg" },
+        {
+          "name": "煎饼果子",
+          "commons_file": "File:Jianbing Guozi 20170610.jpg"
+        },
+        { "name": "锅包肉", "commons_file": "File:Guōbāoròu.jpg" },
+        {
+          "name": "烤冷面",
+          "commons_file": "File:Grilled cold noodles (20241101).jpg"
+        }
+      ]
+    },
+    {
+      "name": "西北风味",
+      "foods": [
+        { "name": "牛肉面", "commons_file": "File:兰州牛肉面.jpg" },
+        { "name": "凉皮", "commons_file": "File:Liangpi.JPG" },
+        { "name": "肉夹馍", "commons_file": "File:Xi'an roujiamo 05.jpg" },
+        { "name": "烤羊肉串", "commons_file": "File:新疆羊肉串.jpg" }
+      ]
+    },
+    {
+      "name": "广西及云南风味",
+      "foods": [
+        {
+          "name": "螺蛳粉",
+          "commons_file": "File:Luosifen at Guangya, Liuzhou (20190420141814).jpg"
+        },
+        {
+          "name": "桂林米粉",
+          "commons_file": "File:Guilin rice noodles in Beijing (20150915111711).jpg"
+        },
+        {
+          "name": "米线",
+          "commons_file": "File:米线 Rice Noodles - 原味小吃 Yuanwei Xiaochi Y3.jpg"
+        }
+      ]
+    },
+    {
+      "name": "全国常见家常菜、快餐及街头小吃",
+      "foods": [
+        { "name": "烤肉", "commons_file": "File:烤肉 (5904967326).jpg" },
+        {
+          "name": "番茄炒蛋",
+          "commons_file": "File:Stir Fried Tomatoes with Scrambled Eggs.jpg"
+        },
+        { "name": "黄焖鸡米饭", "commons_file": "File:黄焖鸡米饭.jpg" },
+        {
+          "name": "盖浇饭",
+          "commons_file": "File:Rice with 3 toppings at a food court in Fangcaodi (20210923124853).jpg"
+        },
+        { "name": "炒饭", "commons_file": "File:Chinese fried rice.jpg" },
+        { "name": "烧烤", "commons_file": "File:Barbecue skewers.jpg" },
+        {
+          "name": "自选菜",
+          "commons_file": "File:Buffet dishes at Khua Din Restaurant.jpg"
+        },
+        { "name": "糖醋里脊", "commons_file": "File:Sweet-and-sour pork.jpg" },
+        { "name": "可乐鸡翅", "commons_file": "File:可乐鸡翅.jpg" },
+        {
+          "name": "红烧排骨",
+          "commons_file": "File:红烧排骨 Braised Pork Ribs - Dainty Sichuan (2283778476).jpg"
+        },
+        {
+          "name": "春卷",
+          "commons_file": "File:Golden Vegetable Spring Rolls Served with Dipping Sauce.jpg"
+        },
+        { "name": "粽子", "commons_file": "File:Zongzi.jpg" },
+        { "name": "鸡排", "commons_file": "File:Chicken-cutlet.jpg" },
+        { "name": "烤红薯", "commons_file": "File:Ishi yaki imo by Kanko.jpg" }
+      ]
+    },
+    {
+      "name": "日本料理",
+      "foods": [
+        { "name": "咖喱饭", "commons_file": "File:日式咖喱饭.jpg" },
+        {
+          "name": "寿司",
+          "commons_file": "File:Sushi platter, Nikko, Japan.jpg"
+        },
+        {
+          "name": "日式拉面",
+          "commons_file": "File:A bowl of ramen in Osaka, Japan.jpg"
+        },
+        { "name": "章鱼烧", "commons_file": "File:Takoyaki at Macha Café.jpg" },
+        { "name": "乌冬面", "commons_file": "File:Bowl of Kitsune Udon.jpg" },
+        { "name": "天妇罗", "commons_file": "File:Tempura.JPG" },
+        { "name": "蛋包饭", "commons_file": "File:Omurice by Taimeiken.jpg" },
+        {
+          "name": "关东煮",
+          "commons_file": "File:Oden, Japanese food for winter.jpg"
+        }
+      ]
+    },
+    {
+      "name": "韩国料理",
+      "foods": [
+        {
+          "name": "石锅拌饭",
+          "commons_file": "File:Bibimbap in stone bowl 비빔밥 (5534738694).jpg"
+        }
+      ]
+    },
+    {
+      "name": "东南亚及南亚料理",
+      "foods": [
+        {
+          "name": "海南鸡饭",
+          "commons_file": "File:Home-cooked Hainanese chicken rice.jpg"
+        },
+        { "name": "越南河粉", "commons_file": "File:Bowl of Meatball pho.jpg" },
+        {
+          "name": "冬阴功",
+          "commons_file": "File:Tom Yum Koong Soup with Prawn and Straw Mushroom.jpg"
+        },
+        { "name": "咖喱鸡", "commons_file": "File:A chicken curry dish.jpg" }
+      ]
+    },
+    {
+      "name": "欧美常见餐食",
+      "foods": [
+        {
+          "name": "汉堡",
+          "commons_file": "File:NCI Visuals Food Hamburger.jpg"
+        },
+        { "name": "披萨", "commons_file": "File:Vegetarian Pizza.jpg" },
+        { "name": "炸鸡", "commons_file": "File:Fried-Chicken-Set.jpg" },
+        { "name": "轻食沙拉", "commons_file": "File:Healthy Green Salad.JPG" },
+        { "name": "意大利面", "commons_file": "File:Spaghetti bolognese.jpg" },
+        {
+          "name": "牛排",
+          "commons_file": "File:Steak-frites (steak-and-chips).jpg"
+        },
+        {
+          "name": "三明治",
+          "commons_file": "File:Classic Club Sandwich, Dôme East Fremantle, 2026 (02).jpg"
+        },
+        {
+          "name": "墨西哥卷饼",
+          "commons_file": "File:(20251114) Chicken burrito 01.jpg"
+        },
+        { "name": "薯条", "commons_file": "File:French Fries.JPG" },
+        { "name": "热狗", "commons_file": "File:Hot dog with mustard.png" }
+      ]
+    }
+  ]
+}

--- a/public/foods.json
+++ b/public/foods.json
@@ -4,7 +4,7 @@
     {
       "name": "川渝风味",
       "foods": [
-        { "name": "火锅", "commons_file": "File:Hot pot dinner.jpg" },
+        { "name": "火锅", "commons_file": "File:Chengdu hot pot.jpg" },
         {
           "name": "麻辣烫",
           "commons_file": "File:Malatang from Hope Tree (20220226172344).jpg"
@@ -12,7 +12,7 @@
         { "name": "冒菜", "commons_file": "File:传奇冒菜 1.jpg" },
         {
           "name": "串串香",
-          "commons_file": "File:冷锅 串 Cold-pot Skewers Y1 per skewer (1495465364).jpg"
+          "commons_file": "File:Fried Chuan.jpg"
         },
         {
           "name": "酸菜鱼",
@@ -123,7 +123,10 @@
           "commons_file": "File:2016-08-27 Peking Duck at Great Wall Restaurant Beijing anagoria.jpg"
         },
         { "name": "炸酱面", "commons_file": "File:Zhajiangmian in Handan.jpg" },
-        { "name": "刀削面", "commons_file": "File:Datong Daoxiaomian.jpg" },
+        {
+          "name": "刀削面",
+          "commons_file": "File:Daoxiaomian at Beixinqiao, Beijing (20201011183536).jpg"
+        },
         {
           "name": "饺子",
           "commons_file": "File:中国饺子（Jiaozi；Dumplings；餃子）.jpg"
@@ -170,10 +173,13 @@
     {
       "name": "全国常见家常菜、快餐及街头小吃",
       "foods": [
-        { "name": "烤肉", "commons_file": "File:烤肉 (5904967326).jpg" },
+        {
+          "name": "烤肉",
+          "commons_file": "File:Smoky grilled pork and dodo.jpg"
+        },
         {
           "name": "番茄炒蛋",
-          "commons_file": "File:Stir Fried Tomatoes with Scrambled Eggs.jpg"
+          "commons_file": "File:番茄炒蛋2.PNG"
         },
         { "name": "黄焖鸡米饭", "commons_file": "File:黄焖鸡米饭.jpg" },
         {
@@ -182,10 +188,6 @@
         },
         { "name": "炒饭", "commons_file": "File:Chinese fried rice.jpg" },
         { "name": "烧烤", "commons_file": "File:Barbecue skewers.jpg" },
-        {
-          "name": "自选菜",
-          "commons_file": "File:Buffet dishes at Khua Din Restaurant.jpg"
-        },
         { "name": "糖醋里脊", "commons_file": "File:Sweet-and-sour pork.jpg" },
         { "name": "可乐鸡翅", "commons_file": "File:可乐鸡翅.jpg" },
         {
@@ -259,7 +261,10 @@
         },
         { "name": "披萨", "commons_file": "File:Vegetarian Pizza.jpg" },
         { "name": "炸鸡", "commons_file": "File:Fried-Chicken-Set.jpg" },
-        { "name": "轻食沙拉", "commons_file": "File:Healthy Green Salad.JPG" },
+        {
+          "name": "轻食沙拉",
+          "commons_file": "File:Healthy Lentil Salad (Unsplash).jpg"
+        },
         { "name": "意大利面", "commons_file": "File:Spaghetti bolognese.jpg" },
         {
           "name": "牛排",
@@ -267,7 +272,7 @@
         },
         {
           "name": "三明治",
-          "commons_file": "File:Classic Club Sandwich, Dôme East Fremantle, 2026 (02).jpg"
+          "commons_file": "File:Club sandwich at Café Picnic.jpg"
         },
         {
           "name": "墨西哥卷饼",

--- a/public/foods.json
+++ b/public/foods.json
@@ -4,46 +4,118 @@
     {
       "name": "川渝风味",
       "foods": [
-        { "name": "火锅", "commons_file": "File:Chengdu hot pot.jpg" },
+        {
+          "name": "火锅",
+          "image": {
+            "provider": "commons",
+            "id": "File:Chengdu hot pot.jpg"
+          }
+        },
         {
           "name": "麻辣烫",
-          "commons_file": "File:Malatang from Hope Tree (20220226172344).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Malatang from Hope Tree (20220226172344).jpg"
+          }
         },
-        { "name": "冒菜", "commons_file": "File:传奇冒菜 1.jpg" },
+        {
+          "name": "冒菜",
+          "image": {
+            "provider": "commons",
+            "id": "File:传奇冒菜 1.jpg"
+          }
+        },
         {
           "name": "串串香",
-          "commons_file": "File:Fried Chuan.jpg"
+          "image": {
+            "provider": "openverse",
+            "id": "8e4f0401-a9ec-4a53-b521-eae1323d6ff7"
+          }
         },
         {
           "name": "酸菜鱼",
-          "commons_file": "File:酸菜鱼 Preserved Mustard Green with Fish - Charming Spice AUD24.80 (4104355401).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:酸菜鱼 Preserved Mustard Green with Fish - Charming Spice AUD24.80 (4104355401).jpg"
+          }
         },
         {
           "name": "水煮肉片",
-          "commons_file": "File:Shuizhu Roupian at Daqian Restaurant, Dachenglu (20260126131330).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Shuizhu Roupian at Daqian Restaurant, Dachenglu (20260126131330).jpg"
+          }
         },
-        { "name": "烤鱼", "commons_file": "File:Grilled Fish with Douhua.jpg" },
+        {
+          "name": "烤鱼",
+          "image": {
+            "provider": "commons",
+            "id": "File:Grilled Fish with Douhua.jpg"
+          }
+        },
         {
           "name": "宫保鸡丁",
-          "commons_file": "File:2016-08-14 Kung Pao Chicken dish in Beijing anagoria.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:2016-08-14 Kung Pao Chicken dish in Beijing anagoria.jpg"
+          }
         },
-        { "name": "鱼香肉丝", "commons_file": "File:川菜鱼香肉丝.jpg" },
+        {
+          "name": "鱼香肉丝",
+          "image": {
+            "provider": "commons",
+            "id": "File:川菜鱼香肉丝.jpg"
+          }
+        },
         {
           "name": "回锅肉",
-          "commons_file": "File:Twice cooked pork, Jia Yan, 5 rue Humblot, Paris 003.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Twice cooked pork, Jia Yan, 5 rue Humblot, Paris 003.jpg"
+          }
         },
-        { "name": "口水鸡", "commons_file": "File:Koushuiji.jpg" },
+        {
+          "name": "口水鸡",
+          "image": {
+            "provider": "commons",
+            "id": "File:Koushuiji.jpg"
+          }
+        },
         {
           "name": "辣子鸡",
-          "commons_file": "File:Làzijī (chicken with chilies).png"
+          "image": {
+            "provider": "commons",
+            "id": "File:Làzijī (chicken with chilies).png"
+          }
         },
-        { "name": "担担面", "commons_file": "File:Dandan Noodles.jpg" },
-        { "name": "麻婆豆腐", "commons_file": "File:麻婆豆腐2024.jpg" },
+        {
+          "name": "担担面",
+          "image": {
+            "provider": "commons",
+            "id": "File:Dandan Noodles.jpg"
+          }
+        },
+        {
+          "name": "麻婆豆腐",
+          "image": {
+            "provider": "commons",
+            "id": "File:麻婆豆腐2024.jpg"
+          }
+        },
         {
           "name": "毛血旺",
-          "commons_file": "File:Chongqing-style boiled blood curd (Mao Xuewang).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Chongqing-style boiled blood curd (Mao Xuewang).jpg"
+          }
         },
-        { "name": "重庆小面", "commons_file": "File:重庆小面 - 2024-05-25.jpg" }
+        {
+          "name": "重庆小面",
+          "image": {
+            "provider": "commons",
+            "id": "File:重庆小面 - 2024-05-25.jpg"
+          }
+        }
       ]
     },
     {
@@ -51,13 +123,25 @@
       "foods": [
         {
           "name": "小炒肉",
-          "commons_file": "File:Lajiao Chaorou at Xiangzhongyuan Hunan Cuisine, Beijing (20240131171407).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Lajiao Chaorou at Xiangzhongyuan Hunan Cuisine, Beijing (20240131171407).jpg"
+          }
         },
         {
           "name": "剁椒鱼头",
-          "commons_file": "File:Hunan cuisine, steamed fish head in chili sauce.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Hunan cuisine, steamed fish head in chili sauce.jpg"
+          }
         },
-        { "name": "热干面", "commons_file": "File:Hot dry noodles.jpg" }
+        {
+          "name": "热干面",
+          "image": {
+            "provider": "commons",
+            "id": "File:Hot dry noodles.jpg"
+          }
+        }
       ]
     },
     {
@@ -65,54 +149,135 @@
       "foods": [
         {
           "name": "白切鸡",
-          "commons_file": "File:HK SYP 西環 Sai Ying Pun 德輔道西 308 Des Voeux Road West 食神麗宮酒家 Chinese Banquet Seafood Restaurant food 海南 文昌 白切雞 Hainan Wenchang White Cut Chicken January 2026 N13P 03.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:HK SYP 西環 Sai Ying Pun 德輔道西 308 Des Voeux Road West 食神麗宮酒家 Chinese Banquet Seafood Restaurant food 海南 文昌 白切雞 Hainan Wenchang White Cut Chicken January 2026 N13P 03.jpg"
+          }
         },
-        { "name": "烧鹅", "commons_file": "File:Cantonese roasted goose.jpg" },
+        {
+          "name": "烧鹅",
+          "image": {
+            "provider": "commons",
+            "id": "File:Cantonese roasted goose.jpg"
+          }
+        },
         {
           "name": "叉烧",
-          "commons_file": "File:Char siu, West Villa Restaurant, Hong Kong - 20160221.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Char siu, West Villa Restaurant, Hong Kong - 20160221.jpg"
+          }
         },
-        { "name": "梅菜扣肉", "commons_file": "File:11月17日 梅菜扣肉.jpg" },
+        {
+          "name": "梅菜扣肉",
+          "image": {
+            "provider": "commons",
+            "id": "File:11月17日 梅菜扣肉.jpg"
+          }
+        },
         {
           "name": "煲仔饭",
-          "commons_file": "File:Claypot Chicken Rice, Singapore.JPG"
+          "image": {
+            "provider": "commons",
+            "id": "File:Claypot Chicken Rice, Singapore.JPG"
+          }
         },
         {
           "name": "肠粉",
-          "commons_file": "File:Dried shrimp rice noodle roll.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Dried shrimp rice noodle roll.jpg"
+          }
         },
         {
           "name": "炒河粉",
-          "commons_file": "File:Dry Fried Beef Ho Fun - Ho Chiak 2023-12-08.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Dry Fried Beef Ho Fun - Ho Chiak 2023-12-08.jpg"
+          }
         },
-        { "name": "云吞面", "commons_file": "File:Wonton egg noodle soup.jpg" },
+        {
+          "name": "云吞面",
+          "image": {
+            "provider": "commons",
+            "id": "File:Wonton egg noodle soup.jpg"
+          }
+        },
         {
           "name": "烧卖",
-          "commons_file": "File:HK SW 上環 Sheung Wan 星月樓 Sky Cuisine Restaurant Friday morning 早餐 breakfast steamed 燒賣 siu mai 點心 dim sum March 2026 N13P 04.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:HK SW 上環 Sheung Wan 星月樓 Sky Cuisine Restaurant Friday morning 早餐 breakfast steamed 燒賣 siu mai 點心 dim sum March 2026 N13P 04.jpg"
+          }
         },
         {
           "name": "蛋挞",
-          "commons_file": "File:Portuguese egg tart in Macau.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Portuguese egg tart in Macau.jpg"
+          }
         },
         {
           "name": "粥",
-          "commons_file": "File:A Bowl of Congee in Tuen Mun.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:A Bowl of Congee in Tuen Mun.jpg"
+          }
         }
       ]
     },
     {
       "name": "江浙沪风味",
       "foods": [
-        { "name": "红烧肉", "commons_file": "File:Red braised pork belly.jpg" },
-        { "name": "东坡肉", "commons_file": "File:Dongpo pork garnished.jpg" },
-        { "name": "糖醋排骨", "commons_file": "File:糖醋排骨.JPG" },
+        {
+          "name": "红烧肉",
+          "image": {
+            "provider": "commons",
+            "id": "File:Red braised pork belly.jpg"
+          }
+        },
+        {
+          "name": "东坡肉",
+          "image": {
+            "provider": "commons",
+            "id": "File:Dongpo pork garnished.jpg"
+          }
+        },
+        {
+          "name": "糖醋排骨",
+          "image": {
+            "provider": "commons",
+            "id": "File:糖醋排骨.JPG"
+          }
+        },
         {
           "name": "小笼包",
-          "commons_file": "File:Xiao Long Bao by Junhao!.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Xiao Long Bao by Junhao!.jpg"
+          }
         },
-        { "name": "生煎包", "commons_file": "File:Shengjian mantou.jpg" },
-        { "name": "葱油拌面", "commons_file": "File:葱花葱油拌面.jpg" },
-        { "name": "馄饨", "commons_file": "File:Wonton.jpg" }
+        {
+          "name": "生煎包",
+          "image": {
+            "provider": "commons",
+            "id": "File:Shengjian mantou.jpg"
+          }
+        },
+        {
+          "name": "葱油拌面",
+          "image": {
+            "provider": "commons",
+            "id": "File:葱花葱油拌面.jpg"
+          }
+        },
+        {
+          "name": "馄饨",
+          "image": {
+            "provider": "commons",
+            "id": "File:Wonton.jpg"
+          }
+        }
       ]
     },
     {
@@ -120,37 +285,100 @@
       "foods": [
         {
           "name": "北京烤鸭",
-          "commons_file": "File:2016-08-27 Peking Duck at Great Wall Restaurant Beijing anagoria.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:2016-08-27 Peking Duck at Great Wall Restaurant Beijing anagoria.jpg"
+          }
         },
-        { "name": "炸酱面", "commons_file": "File:Zhajiangmian in Handan.jpg" },
+        {
+          "name": "炸酱面",
+          "image": {
+            "provider": "commons",
+            "id": "File:Zhajiangmian in Handan.jpg"
+          }
+        },
         {
           "name": "刀削面",
-          "commons_file": "File:Daoxiaomian at Beixinqiao, Beijing (20201011183536).jpg"
+          "image": {
+            "provider": "openverse",
+            "id": "70eba2cd-ffaa-4070-858d-db17e169e9a9"
+          }
         },
         {
           "name": "饺子",
-          "commons_file": "File:中国饺子（Jiaozi；Dumplings；餃子）.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:中国饺子（Jiaozi；Dumplings；餃子）.jpg"
+          }
         },
-        { "name": "包子", "commons_file": "File:Baozi.JPG" },
-        { "name": "锅贴", "commons_file": "File:Potstickers RTE.jpg" },
+        {
+          "name": "包子",
+          "image": {
+            "provider": "commons",
+            "id": "File:Baozi.JPG"
+          }
+        },
+        {
+          "name": "锅贴",
+          "image": {
+            "provider": "commons",
+            "id": "File:Potstickers RTE.jpg"
+          }
+        },
         {
           "name": "煎饼果子",
-          "commons_file": "File:Jianbing Guozi 20170610.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Jianbing Guozi 20170610.jpg"
+          }
         },
-        { "name": "锅包肉", "commons_file": "File:Guōbāoròu.jpg" },
+        {
+          "name": "锅包肉",
+          "image": {
+            "provider": "commons",
+            "id": "File:Guōbāoròu.jpg"
+          }
+        },
         {
           "name": "烤冷面",
-          "commons_file": "File:Grilled cold noodles (20241101).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Grilled cold noodles (20241101).jpg"
+          }
         }
       ]
     },
     {
       "name": "西北风味",
       "foods": [
-        { "name": "牛肉面", "commons_file": "File:兰州牛肉面.jpg" },
-        { "name": "凉皮", "commons_file": "File:Liangpi.JPG" },
-        { "name": "肉夹馍", "commons_file": "File:Xi'an roujiamo 05.jpg" },
-        { "name": "烤羊肉串", "commons_file": "File:新疆羊肉串.jpg" }
+        {
+          "name": "牛肉面",
+          "image": {
+            "provider": "commons",
+            "id": "File:兰州牛肉面.jpg"
+          }
+        },
+        {
+          "name": "凉皮",
+          "image": {
+            "provider": "commons",
+            "id": "File:Liangpi.JPG"
+          }
+        },
+        {
+          "name": "肉夹馍",
+          "image": {
+            "provider": "commons",
+            "id": "File:Xi'an roujiamo 05.jpg"
+          }
+        },
+        {
+          "name": "烤羊肉串",
+          "image": {
+            "provider": "commons",
+            "id": "File:新疆羊肉串.jpg"
+          }
+        }
       ]
     },
     {
@@ -158,15 +386,24 @@
       "foods": [
         {
           "name": "螺蛳粉",
-          "commons_file": "File:Luosifen at Guangya, Liuzhou (20190420141814).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Luosifen at Guangya, Liuzhou (20190420141814).jpg"
+          }
         },
         {
           "name": "桂林米粉",
-          "commons_file": "File:Guilin rice noodles in Beijing (20150915111711).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Guilin rice noodles in Beijing (20150915111711).jpg"
+          }
         },
         {
           "name": "米线",
-          "commons_file": "File:米线 Rice Noodles - 原味小吃 Yuanwei Xiaochi Y3.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:米线 Rice Noodles - 原味小吃 Yuanwei Xiaochi Y3.jpg"
+          }
         }
       ]
     },
@@ -175,53 +412,155 @@
       "foods": [
         {
           "name": "烤肉",
-          "commons_file": "File:Smoky grilled pork and dodo.jpg"
+          "image": {
+            "provider": "openverse",
+            "id": "09cfa4d3-87db-405a-858c-7504b31cf359"
+          }
         },
         {
           "name": "番茄炒蛋",
-          "commons_file": "File:番茄炒蛋2.PNG"
+          "image": {
+            "provider": "openverse",
+            "id": "274f3029-f595-40d0-ad68-2edff610f4af"
+          }
         },
-        { "name": "黄焖鸡米饭", "commons_file": "File:黄焖鸡米饭.jpg" },
+        {
+          "name": "黄焖鸡米饭",
+          "image": {
+            "provider": "commons",
+            "id": "File:黄焖鸡米饭.jpg"
+          }
+        },
         {
           "name": "盖浇饭",
-          "commons_file": "File:Rice with 3 toppings at a food court in Fangcaodi (20210923124853).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Rice with 3 toppings at a food court in Fangcaodi (20210923124853).jpg"
+          }
         },
-        { "name": "炒饭", "commons_file": "File:Chinese fried rice.jpg" },
-        { "name": "烧烤", "commons_file": "File:Barbecue skewers.jpg" },
-        { "name": "糖醋里脊", "commons_file": "File:Sweet-and-sour pork.jpg" },
-        { "name": "可乐鸡翅", "commons_file": "File:可乐鸡翅.jpg" },
+        {
+          "name": "炒饭",
+          "image": {
+            "provider": "commons",
+            "id": "File:Chinese fried rice.jpg"
+          }
+        },
+        {
+          "name": "烧烤",
+          "image": {
+            "provider": "commons",
+            "id": "File:Barbecue skewers.jpg"
+          }
+        },
+        {
+          "name": "糖醋里脊",
+          "image": {
+            "provider": "commons",
+            "id": "File:Sweet-and-sour pork.jpg"
+          }
+        },
+        {
+          "name": "可乐鸡翅",
+          "image": {
+            "provider": "commons",
+            "id": "File:可乐鸡翅.jpg"
+          }
+        },
         {
           "name": "红烧排骨",
-          "commons_file": "File:红烧排骨 Braised Pork Ribs - Dainty Sichuan (2283778476).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:红烧排骨 Braised Pork Ribs - Dainty Sichuan (2283778476).jpg"
+          }
         },
         {
           "name": "春卷",
-          "commons_file": "File:Golden Vegetable Spring Rolls Served with Dipping Sauce.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Golden Vegetable Spring Rolls Served with Dipping Sauce.jpg"
+          }
         },
-        { "name": "粽子", "commons_file": "File:Zongzi.jpg" },
-        { "name": "鸡排", "commons_file": "File:Chicken-cutlet.jpg" },
-        { "name": "烤红薯", "commons_file": "File:Ishi yaki imo by Kanko.jpg" }
+        {
+          "name": "粽子",
+          "image": {
+            "provider": "commons",
+            "id": "File:Zongzi.jpg"
+          }
+        },
+        {
+          "name": "鸡排",
+          "image": {
+            "provider": "commons",
+            "id": "File:Chicken-cutlet.jpg"
+          }
+        },
+        {
+          "name": "烤红薯",
+          "image": {
+            "provider": "commons",
+            "id": "File:Ishi yaki imo by Kanko.jpg"
+          }
+        }
       ]
     },
     {
       "name": "日本料理",
       "foods": [
-        { "name": "咖喱饭", "commons_file": "File:日式咖喱饭.jpg" },
+        {
+          "name": "咖喱饭",
+          "image": {
+            "provider": "commons",
+            "id": "File:日式咖喱饭.jpg"
+          }
+        },
         {
           "name": "寿司",
-          "commons_file": "File:Sushi platter, Nikko, Japan.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Sushi platter, Nikko, Japan.jpg"
+          }
         },
         {
           "name": "日式拉面",
-          "commons_file": "File:A bowl of ramen in Osaka, Japan.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:A bowl of ramen in Osaka, Japan.jpg"
+          }
         },
-        { "name": "章鱼烧", "commons_file": "File:Takoyaki at Macha Café.jpg" },
-        { "name": "乌冬面", "commons_file": "File:Bowl of Kitsune Udon.jpg" },
-        { "name": "天妇罗", "commons_file": "File:Tempura.JPG" },
-        { "name": "蛋包饭", "commons_file": "File:Omurice by Taimeiken.jpg" },
+        {
+          "name": "章鱼烧",
+          "image": {
+            "provider": "commons",
+            "id": "File:Takoyaki at Macha Café.jpg"
+          }
+        },
+        {
+          "name": "乌冬面",
+          "image": {
+            "provider": "commons",
+            "id": "File:Bowl of Kitsune Udon.jpg"
+          }
+        },
+        {
+          "name": "天妇罗",
+          "image": {
+            "provider": "commons",
+            "id": "File:Tempura.JPG"
+          }
+        },
+        {
+          "name": "蛋包饭",
+          "image": {
+            "provider": "commons",
+            "id": "File:Omurice by Taimeiken.jpg"
+          }
+        },
         {
           "name": "关东煮",
-          "commons_file": "File:Oden, Japanese food for winter.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Oden, Japanese food for winter.jpg"
+          }
         }
       ]
     },
@@ -230,7 +569,10 @@
       "foods": [
         {
           "name": "石锅拌饭",
-          "commons_file": "File:Bibimbap in stone bowl 비빔밥 (5534738694).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Bibimbap in stone bowl 비빔밥 (5534738694).jpg"
+          }
         }
       ]
     },
@@ -239,16 +581,31 @@
       "foods": [
         {
           "name": "海南鸡饭",
-          "commons_file": "File:Hainanese chicken rice.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Hainanese chicken rice.jpg"
+          }
         },
-        { "name": "越南河粉", "commons_file": "File:Bowl of Meatball pho.jpg" },
+        {
+          "name": "越南河粉",
+          "image": {
+            "provider": "commons",
+            "id": "File:Bowl of Meatball pho.jpg"
+          }
+        },
         {
           "name": "冬阴功",
-          "commons_file": "File:Tom Yum Koong Soup with Prawn and Straw Mushroom.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Tom Yum Koong Soup with Prawn and Straw Mushroom.jpg"
+          }
         },
         {
           "name": "咖喱鸡",
-          "commons_file": "File:Red Curry with Chicken - Little Thai, Brighton 2024-03-01.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Red Curry with Chicken - Little Thai, Brighton 2024-03-01.jpg"
+          }
         }
       ]
     },
@@ -257,29 +614,74 @@
       "foods": [
         {
           "name": "汉堡",
-          "commons_file": "File:NCI Visuals Food Hamburger.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:NCI Visuals Food Hamburger.jpg"
+          }
         },
-        { "name": "披萨", "commons_file": "File:Vegetarian Pizza.jpg" },
-        { "name": "炸鸡", "commons_file": "File:Fried-Chicken-Set.jpg" },
+        {
+          "name": "披萨",
+          "image": {
+            "provider": "commons",
+            "id": "File:Vegetarian Pizza.jpg"
+          }
+        },
+        {
+          "name": "炸鸡",
+          "image": {
+            "provider": "commons",
+            "id": "File:Fried-Chicken-Set.jpg"
+          }
+        },
         {
           "name": "轻食沙拉",
-          "commons_file": "File:Healthy Lentil Salad (Unsplash).jpg"
+          "image": {
+            "provider": "openverse",
+            "id": "c8314f30-7bff-406f-b658-8d593ff80e0d"
+          }
         },
-        { "name": "意大利面", "commons_file": "File:Spaghetti bolognese.jpg" },
+        {
+          "name": "意大利面",
+          "image": {
+            "provider": "commons",
+            "id": "File:Spaghetti bolognese.jpg"
+          }
+        },
         {
           "name": "牛排",
-          "commons_file": "File:Steak-frites (steak-and-chips).jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:Steak-frites (steak-and-chips).jpg"
+          }
         },
         {
           "name": "三明治",
-          "commons_file": "File:Club sandwich at Café Picnic.jpg"
+          "image": {
+            "provider": "openverse",
+            "id": "7ef1012f-52dd-4162-8c21-979a6455a604"
+          }
         },
         {
           "name": "墨西哥卷饼",
-          "commons_file": "File:(20251114) Chicken burrito 01.jpg"
+          "image": {
+            "provider": "commons",
+            "id": "File:(20251114) Chicken burrito 01.jpg"
+          }
         },
-        { "name": "薯条", "commons_file": "File:French Fries.JPG" },
-        { "name": "热狗", "commons_file": "File:Hot dog with mustard.png" }
+        {
+          "name": "薯条",
+          "image": {
+            "provider": "commons",
+            "id": "File:French Fries.JPG"
+          }
+        },
+        {
+          "name": "热狗",
+          "image": {
+            "provider": "commons",
+            "id": "File:Hot dog with mustard.png"
+          }
+        }
       ]
     }
   ]

--- a/src/plugins/ff14/__init__.py
+++ b/src/plugins/ff14/__init__.py
@@ -8,6 +8,7 @@ from nonebot.plugin import PluginMetadata, inherit_supported_adapters
 
 require("nonebot_plugin_apscheduler")
 require("nonebot_plugin_datastore")
+require("nonebot_plugin_localstore")
 require("nonebot_plugin_orm")
 require("nonebot_plugin_user")
 require("src.utils.group_bind")

--- a/src/plugins/ff14/plugins/ff14_fflogs/__init__.py
+++ b/src/plugins/ff14/plugins/ff14_fflogs/__init__.py
@@ -15,6 +15,7 @@ from nonebot_plugin_user import UserSession, get_user
 
 from src.utils.helpers import strtobool
 from src.utils.permission import is_superuser
+from src.utils.remote_data import RemoteDataError
 
 from .api import fflogs
 from .config import plugin_config
@@ -73,8 +74,11 @@ async def fflogs_handle(session: UserSession, argv: tuple[str | At, ...]):
         await fflogs_cmd.finish("对不起，Token 未设置，无法查询数据。\n请先在 .env 中配置好 Token 后再尝试查询数据。")
 
     if argv[0] == "update" and len(argv) == 1:
-        await FFLOGS_DATA.update()
-        data = await FFLOGS_DATA.data
+        try:
+            data = await FFLOGS_DATA.update()
+        except RemoteDataError as e:
+            logger.warning("副本数据更新失败: {}", e)
+            await fflogs_cmd.finish("副本数据更新失败，已保留原缓存。")
         await fflogs_cmd.finish(f"副本数据更新成功，当前版本为 {data.version}。")
 
     # 缓存相关设置

--- a/src/plugins/ff14/plugins/ff14_fflogs/data.py
+++ b/src/plugins/ff14/plugins/ff14_fflogs/data.py
@@ -3,11 +3,11 @@
 副本与职业数据
 """
 
-from nonebot_plugin_datastore import get_plugin_data
+from nonebot_plugin_localstore import get_cache_file
+
+from src.utils.remote_data import RemoteJsonData
 
 from .models import BossInfo, FFlogsDataModel, JobInfo
-
-plugin_data = get_plugin_data()
 
 
 def parse_data(data: dict) -> FFlogsDataModel:
@@ -15,11 +15,10 @@ def parse_data(data: dict) -> FFlogsDataModel:
     return FFlogsDataModel.model_validate(data)
 
 
-FFLOGS_DATA = plugin_data.network_file(
+FFLOGS_DATA = RemoteJsonData(
     "https://bot-docs.hehome.xyz/fflogs_data.json",
-    "fflogs_data.json",
+    lambda: get_cache_file("ff14_fflogs", "fflogs_data.json"),
     parse_data,
-    cache=True,
 )
 
 

--- a/src/plugins/ff14/plugins/ff14_fflogs/data.py
+++ b/src/plugins/ff14/plugins/ff14_fflogs/data.py
@@ -3,7 +3,7 @@
 副本与职业数据
 """
 
-from nonebot_plugin_localstore import get_cache_file
+from nonebot_plugin_localstore import get_plugin_cache_dir
 
 from src.utils.remote_data import RemoteJsonData
 
@@ -17,7 +17,7 @@ def parse_data(data: dict) -> FFlogsDataModel:
 
 FFLOGS_DATA = RemoteJsonData(
     "https://bot-docs.hehome.xyz/fflogs_data.json",
-    lambda: get_cache_file("ff14_fflogs", "fflogs_data.json"),
+    lambda: get_plugin_cache_dir() / "fflogs_data.json",
     parse_data,
 )
 

--- a/src/plugins/morning/__init__.py
+++ b/src/plugins/morning/__init__.py
@@ -8,6 +8,7 @@ from nonebot.plugin import PluginMetadata, inherit_supported_adapters
 
 require("nonebot_plugin_apscheduler")
 require("nonebot_plugin_datastore")
+require("nonebot_plugin_localstore")
 require("nonebot_plugin_orm")
 require("nonebot_plugin_saa")
 require("nonebot_plugin_alconna")

--- a/src/plugins/morning/plugins/morning_greeting/__init__.py
+++ b/src/plugins/morning/plugins/morning_greeting/__init__.py
@@ -15,6 +15,7 @@ from sqlalchemy import select
 from src.plugins.morning import plugin_config
 from src.utils.annotated import AsyncSession
 from src.utils.helpers import admin_permission, strtobool
+from src.utils.remote_data import RemoteDataError
 
 from .data_source import HOLIDAYS_DATA, get_moring_message
 from .models import MorningGreeting
@@ -91,7 +92,11 @@ async def morning_handle(session: AsyncSession, arg: Match[str], target: Platfor
             await morning_cmd.finish(await get_moring_message())
 
         if arg.result == "update":
-            await HOLIDAYS_DATA.update()
+            try:
+                await HOLIDAYS_DATA.update()
+            except RemoteDataError as e:
+                logger.warning("节假日数据更新失败: {}", e)
+                await morning_cmd.finish("节假日数据更新失败，已保留原缓存")
             await morning_cmd.finish("节假日数据更新成功")
 
     group = (

--- a/src/plugins/morning/plugins/morning_greeting/data_source.py
+++ b/src/plugins/morning/plugins/morning_greeting/data_source.py
@@ -2,12 +2,11 @@ from datetime import date, timedelta
 from typing import TypedDict
 
 from dateutil import parser
-from nonebot_plugin_datastore import get_plugin_data
+from nonebot_plugin_localstore import get_cache_file
 
 from src.plugins.llm.tools import registry
 from src.utils.helpers import render_expression
-
-plugin_data = get_plugin_data()
+from src.utils.remote_data import RemoteJsonData
 
 
 class HolidayInfo(TypedDict):
@@ -33,11 +32,10 @@ def process_data(data: dict) -> dict:
     return holidays
 
 
-HOLIDAYS_DATA = plugin_data.network_file(
+HOLIDAYS_DATA = RemoteJsonData(
     "https://bot-docs.hehome.xyz/holidays.json",
-    "holidays.json",
+    lambda: get_cache_file("morning_greeting", "holidays.json"),
     process_data,
-    cache=True,
 )
 
 

--- a/src/plugins/morning/plugins/morning_greeting/data_source.py
+++ b/src/plugins/morning/plugins/morning_greeting/data_source.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 from typing import TypedDict
 
 from dateutil import parser
-from nonebot_plugin_localstore import get_cache_file
+from nonebot_plugin_localstore import get_plugin_cache_dir
 
 from src.plugins.llm.tools import registry
 from src.utils.helpers import render_expression
@@ -34,7 +34,7 @@ def process_data(data: dict) -> dict:
 
 HOLIDAYS_DATA = RemoteJsonData(
     "https://bot-docs.hehome.xyz/holidays.json",
-    lambda: get_cache_file("morning_greeting", "holidays.json"),
+    lambda: get_plugin_cache_dir() / "holidays.json",
     process_data,
 )
 

--- a/src/plugins/what_to_eat/__init__.py
+++ b/src/plugins/what_to_eat/__init__.py
@@ -9,6 +9,8 @@ from nonebot.plugin import PluginMetadata, inherit_supported_adapters
 
 require("nonebot_plugin_localstore")
 from nonebot_plugin_alconna import Alconna, Args, CommandMeta, Image, MultiVar, Subcommand, Text, on_alconna
+from nonebot_plugin_alconna.builtins.extensions.discord import DiscordSlashExtension
+from nonebot_plugin_alconna.builtins.extensions.telegram import TelegramSlashExtension
 
 from src.utils.helpers import admin_permission
 from src.utils.remote_data import RemoteDataError
@@ -20,17 +22,18 @@ __plugin_meta__ = PluginMetadata(
     name="吃什么",
     description="随机推荐一种美食",
     usage="""随机推荐一种美食
-吃什么
+/吃什么
+/what_to_eat（Telegram）
 吃啥？
 今晚吃什么
 今天 中午吃啥？
-管理员更新美食数据：吃什么 update""",
+管理员更新美食数据：/吃什么 update 或 /what_to_eat update""",
     supported_adapters=inherit_supported_adapters("nonebot_plugin_alconna"),
 )
 
 what_to_eat_cmd = on_alconna(
     Alconna(
-        "吃什么",
+        "what_to_eat",
         Subcommand("update", help_text="更新美食数据（仅管理员）"),
         Args["context?#场景", MultiVar(str, flag="+")],
         meta=CommandMeta(
@@ -38,12 +41,19 @@ what_to_eat_cmd = on_alconna(
             example=__plugin_meta__.usage,
         ),
     ),
-    use_cmd_start=False,
+    aliases={"吃什么"},
+    use_cmd_start=True,
     block=True,
+    extensions=[
+        TelegramSlashExtension(),
+        DiscordSlashExtension(name_localizations={"zh-CN": "吃什么"}),
+    ],
 )
 
+_command_prefix = next((prefix for prefix in what_to_eat_cmd.command().prefixes if isinstance(prefix, str)), "")
 what_to_eat_cmd.shortcut(
     re.compile(r"(?P<context>.*?)吃(?:啥|什么)[?？]?"),
+    command=f"{_command_prefix}what_to_eat",
     arguments=["{context}"],
     fuzzy=False,
     compact=False,

--- a/src/plugins/what_to_eat/__init__.py
+++ b/src/plugins/what_to_eat/__init__.py
@@ -8,7 +8,7 @@ from nonebot.log import logger
 from nonebot.plugin import PluginMetadata, inherit_supported_adapters
 
 require("nonebot_plugin_localstore")
-from nonebot_plugin_alconna import Alconna, Args, CommandMeta, Image, MultiVar, Subcommand, Text, on_alconna
+from nonebot_plugin_alconna import Alconna, Args, CommandMeta, Image, Match, MultiVar, Subcommand, Text, on_alconna
 from nonebot_plugin_alconna.builtins.extensions.discord import DiscordSlashExtension
 from nonebot_plugin_alconna.builtins.extensions.telegram import TelegramSlashExtension
 
@@ -62,9 +62,10 @@ what_to_eat_cmd.shortcut(
 
 
 @what_to_eat_cmd.assign("$main")
-async def what_to_eat_handle():
+async def what_to_eat_handle(context: Match[tuple[str, ...]]):
     food = await recommend_food()
-    text = f"推荐你吃：{food.name}！"
+    scene = "".join(context.result).strip() if context.available else ""
+    text = f"{scene}吃{food.name}！" if scene else f"推荐你吃：{food.name}！"
     image = await get_food_image(food.image)
     if not image:
         await what_to_eat_cmd.finish(text, at_sender=True)

--- a/src/plugins/what_to_eat/__init__.py
+++ b/src/plugins/what_to_eat/__init__.py
@@ -65,9 +65,10 @@ what_to_eat_cmd.shortcut(
 async def what_to_eat_handle():
     food = await recommend_food()
     text = f"推荐你吃：{food.name}！"
-    image = await get_food_image(food.commons_file)
+    image = await get_food_image(food.image)
     if not image:
         await what_to_eat_cmd.finish(text, at_sender=True)
+        return
 
     message = Text(f"{text}\n") + Image(raw=image.content, mimetype=image.mimetype)
     message += Text(f"\n{image.attribution}")
@@ -85,4 +86,5 @@ async def what_to_eat_update_handle(bot: Bot, event: Event):
     except RemoteDataError as e:
         logger.warning("美食数据更新失败: {}", e)
         await what_to_eat_cmd.finish("美食数据更新失败，已保留原缓存", at_sender=True)
+        return
     await what_to_eat_cmd.finish(f"美食数据更新成功，数据日期：{dataset.version.isoformat()}", at_sender=True)

--- a/src/plugins/what_to_eat/__init__.py
+++ b/src/plugins/what_to_eat/__init__.py
@@ -81,8 +81,8 @@ async def what_to_eat_update_handle(bot: Bot, event: Event):
         await what_to_eat_cmd.finish("该指令仅管理员可用", at_sender=True)
 
     try:
-        await FOODS_DATA.update()
+        dataset = await FOODS_DATA.update()
     except RemoteDataError as e:
         logger.warning("美食数据更新失败: {}", e)
         await what_to_eat_cmd.finish("美食数据更新失败，已保留原缓存", at_sender=True)
-    await what_to_eat_cmd.finish("美食数据更新成功", at_sender=True)
+    await what_to_eat_cmd.finish(f"美食数据更新成功，数据日期：{dataset.version.isoformat()}", at_sender=True)

--- a/src/plugins/what_to_eat/__init__.py
+++ b/src/plugins/what_to_eat/__init__.py
@@ -2,10 +2,18 @@
 
 import re
 
+from nonebot import require
+from nonebot.adapters import Bot, Event
+from nonebot.log import logger
 from nonebot.plugin import PluginMetadata, inherit_supported_adapters
-from nonebot_plugin_alconna import Alconna, Args, CommandMeta, Image, MultiVar, Text, on_alconna
 
-from .data_source import recommend_food
+require("nonebot_plugin_localstore")
+from nonebot_plugin_alconna import Alconna, Args, CommandMeta, Image, MultiVar, Subcommand, Text, on_alconna
+
+from src.utils.helpers import admin_permission
+from src.utils.remote_data import RemoteDataError
+
+from .data_source import FOODS_DATA, recommend_food
 from .image_api import get_food_image
 
 __plugin_meta__ = PluginMetadata(
@@ -15,13 +23,15 @@ __plugin_meta__ = PluginMetadata(
 吃什么
 吃啥？
 今晚吃什么
-今天 中午吃啥？""",
+今天 中午吃啥？
+管理员更新美食数据：吃什么 update""",
     supported_adapters=inherit_supported_adapters("nonebot_plugin_alconna"),
 )
 
 what_to_eat_cmd = on_alconna(
     Alconna(
         "吃什么",
+        Subcommand("update", help_text="更新美食数据（仅管理员）"),
         Args["context?#场景", MultiVar(str, flag="+")],
         meta=CommandMeta(
             description=__plugin_meta__.description,
@@ -41,9 +51,9 @@ what_to_eat_cmd.shortcut(
 )
 
 
-@what_to_eat_cmd.handle()
+@what_to_eat_cmd.assign("$main")
 async def what_to_eat_handle():
-    food = recommend_food()
+    food = await recommend_food()
     text = f"推荐你吃：{food.name}！"
     image = await get_food_image(food.commons_file)
     if not image:
@@ -52,3 +62,17 @@ async def what_to_eat_handle():
     message = Text(f"{text}\n") + Image(raw=image.content, mimetype=image.mimetype)
     message += Text(f"\n{image.attribution}")
     await what_to_eat_cmd.finish(message, at_sender=True)
+
+
+@what_to_eat_cmd.assign("update")
+async def what_to_eat_update_handle(bot: Bot, event: Event):
+    """由管理员手动拉取 Pages 上的最新美食数据。"""
+    if not await admin_permission()(bot, event):
+        await what_to_eat_cmd.finish("该指令仅管理员可用", at_sender=True)
+
+    try:
+        await FOODS_DATA.update()
+    except RemoteDataError as e:
+        logger.warning("美食数据更新失败: {}", e)
+        await what_to_eat_cmd.finish("美食数据更新失败，已保留原缓存", at_sender=True)
+    await what_to_eat_cmd.finish("美食数据更新成功", at_sender=True)

--- a/src/plugins/what_to_eat/data_source.py
+++ b/src/plugins/what_to_eat/data_source.py
@@ -1,7 +1,13 @@
-"""随机美食推荐。"""
+"""随机美食推荐数据。"""
 
 from dataclasses import dataclass
 from random import choice
+
+from nonebot_plugin_localstore import get_cache_file
+
+from src.utils.remote_data import RemoteJsonData
+
+FOODS_DATA_URL = "https://bot-docs.hehome.xyz/foods.json"
 
 
 @dataclass(frozen=True)
@@ -12,121 +18,48 @@ class Food:
     commons_file: str
 
 
-FOODS = (
-    # 川渝风味
-    Food("火锅", "File:Hot pot dinner.jpg"),
-    Food("麻辣烫", "File:Malatang from Hope Tree (20220226172344).jpg"),
-    Food("冒菜", "File:传奇冒菜 1.jpg"),
-    Food("串串香", "File:冷锅 串 Cold-pot Skewers Y1 per skewer (1495465364).jpg"),
-    Food(
-        "酸菜鱼",
-        "File:酸菜鱼 Preserved Mustard Green with Fish - Charming Spice AUD24.80 (4104355401).jpg",
-    ),
-    Food("水煮肉片", "File:Shuizhu Roupian at Daqian Restaurant, Dachenglu (20260126131330).jpg"),
-    Food("烤鱼", "File:Grilled Fish with Douhua.jpg"),
-    Food("宫保鸡丁", "File:2016-08-14 Kung Pao Chicken dish in Beijing anagoria.jpg"),
-    Food("鱼香肉丝", "File:川菜鱼香肉丝.jpg"),
-    Food("回锅肉", "File:Twice cooked pork, Jia Yan, 5 rue Humblot, Paris 003.jpg"),
-    Food("口水鸡", "File:Koushuiji.jpg"),
-    Food("辣子鸡", "File:Làzijī (chicken with chilies).png"),
-    Food("担担面", "File:Dandan Noodles.jpg"),
-    Food("麻婆豆腐", "File:麻婆豆腐2024.jpg"),
-    Food("毛血旺", "File:Chongqing-style boiled blood curd (Mao Xuewang).jpg"),
-    Food("重庆小面", "File:重庆小面 - 2024-05-25.jpg"),
-    # 湘鄂风味
-    Food("小炒肉", "File:Lajiao Chaorou at Xiangzhongyuan Hunan Cuisine, Beijing (20240131171407).jpg"),
-    Food("剁椒鱼头", "File:Hunan cuisine, steamed fish head in chili sauce.jpg"),
-    Food("热干面", "File:Hot dry noodles.jpg"),
-    # 粤港澳及客家风味
-    Food(
-        "白切鸡",
-        "File:HK SYP 西環 Sai Ying Pun 德輔道西 308 Des Voeux Road West 食神麗宮酒家 Chinese Banquet Seafood Restaurant food 海南 文昌 白切雞 Hainan Wenchang White Cut Chicken January 2026 N13P 03.jpg",
-    ),
-    Food("烧鹅", "File:Cantonese roasted goose.jpg"),
-    Food("叉烧", "File:Char siu, West Villa Restaurant, Hong Kong - 20160221.jpg"),
-    Food("梅菜扣肉", "File:11月17日 梅菜扣肉.jpg"),
-    Food("煲仔饭", "File:Claypot Chicken Rice, Singapore.JPG"),
-    Food("肠粉", "File:Dried shrimp rice noodle roll.jpg"),
-    Food("炒河粉", "File:Dry Fried Beef Ho Fun - Ho Chiak 2023-12-08.jpg"),
-    Food("云吞面", "File:Wonton egg noodle soup.jpg"),
-    Food(
-        "烧卖",
-        "File:HK SW 上環 Sheung Wan 星月樓 Sky Cuisine Restaurant Friday morning 早餐 breakfast steamed 燒賣 siu mai 點心 dim sum March 2026 N13P 04.jpg",
-    ),
-    Food("蛋挞", "File:Portuguese egg tart in Macau.jpg"),
-    Food("粥", "File:A Bowl of Congee in Tuen Mun.jpg"),
-    # 江浙沪风味
-    Food("红烧肉", "File:Red braised pork belly.jpg"),
-    Food("东坡肉", "File:Dongpo pork garnished.jpg"),
-    Food("糖醋排骨", "File:糖醋排骨.JPG"),
-    Food("小笼包", "File:Xiao Long Bao by Junhao!.jpg"),
-    Food("生煎包", "File:Shengjian mantou.jpg"),
-    Food("葱油拌面", "File:葱花葱油拌面.jpg"),
-    Food("馄饨", "File:Wonton.jpg"),
-    # 华北及东北风味
-    Food("北京烤鸭", "File:2016-08-27 Peking Duck at Great Wall Restaurant Beijing anagoria.jpg"),
-    Food("炸酱面", "File:Zhajiangmian in Handan.jpg"),
-    Food("刀削面", "File:Datong Daoxiaomian.jpg"),
-    Food("饺子", "File:中国饺子（Jiaozi；Dumplings；餃子）.jpg"),
-    Food("包子", "File:Baozi.JPG"),
-    Food("锅贴", "File:Potstickers RTE.jpg"),
-    Food("煎饼果子", "File:Jianbing Guozi 20170610.jpg"),
-    Food("锅包肉", "File:Guōbāoròu.jpg"),
-    Food("烤冷面", "File:Grilled cold noodles (20241101).jpg"),
-    # 西北风味
-    Food("牛肉面", "File:兰州牛肉面.jpg"),
-    Food("凉皮", "File:Liangpi.JPG"),
-    Food("肉夹馍", "File:Xi'an roujiamo 05.jpg"),
-    Food("烤羊肉串", "File:新疆羊肉串.jpg"),
-    # 广西及云南风味
-    Food("螺蛳粉", "File:Luosifen at Guangya, Liuzhou (20190420141814).jpg"),
-    Food("桂林米粉", "File:Guilin rice noodles in Beijing (20150915111711).jpg"),
-    Food("米线", "File:米线 Rice Noodles - 原味小吃 Yuanwei Xiaochi Y3.jpg"),
-    # 全国常见家常菜、快餐及街头小吃
-    Food("烤肉", "File:烤肉 (5904967326).jpg"),
-    Food("番茄炒蛋", "File:Stir Fried Tomatoes with Scrambled Eggs.jpg"),
-    Food("黄焖鸡米饭", "File:黄焖鸡米饭.jpg"),
-    Food("盖浇饭", "File:Rice with 3 toppings at a food court in Fangcaodi (20210923124853).jpg"),
-    Food("炒饭", "File:Chinese fried rice.jpg"),
-    Food("烧烤", "File:Barbecue skewers.jpg"),
-    Food("自选菜", "File:Buffet dishes at Khua Din Restaurant.jpg"),
-    Food("糖醋里脊", "File:Sweet-and-sour pork.jpg"),
-    Food("可乐鸡翅", "File:可乐鸡翅.jpg"),
-    Food("红烧排骨", "File:红烧排骨 Braised Pork Ribs - Dainty Sichuan (2283778476).jpg"),
-    Food("春卷", "File:Golden Vegetable Spring Rolls Served with Dipping Sauce.jpg"),
-    Food("粽子", "File:Zongzi.jpg"),
-    Food("鸡排", "File:Chicken-cutlet.jpg"),
-    Food("烤红薯", "File:Ishi yaki imo by Kanko.jpg"),
-    # 日本料理
-    Food("咖喱饭", "File:日式咖喱饭.jpg"),
-    Food("寿司", "File:Sushi platter, Nikko, Japan.jpg"),
-    Food("日式拉面", "File:A bowl of ramen in Osaka, Japan.jpg"),
-    Food("章鱼烧", "File:Takoyaki at Macha Café.jpg"),
-    Food("乌冬面", "File:Bowl of Kitsune Udon.jpg"),
-    Food("天妇罗", "File:Tempura.JPG"),
-    Food("蛋包饭", "File:Omurice by Taimeiken.jpg"),
-    Food("关东煮", "File:Oden, Japanese food for winter.jpg"),
-    # 韩国料理
-    Food("石锅拌饭", "File:Bibimbap in stone bowl 비빔밥 (5534738694).jpg"),
-    # 东南亚及南亚料理
-    Food("海南鸡饭", "File:Home-cooked Hainanese chicken rice.jpg"),
-    Food("越南河粉", "File:Bowl of Meatball pho.jpg"),
-    Food("冬阴功", "File:Tom Yum Koong Soup with Prawn and Straw Mushroom.jpg"),
-    Food("咖喱鸡", "File:A chicken curry dish.jpg"),
-    # 欧美常见餐食
-    Food("汉堡", "File:NCI Visuals Food Hamburger.jpg"),
-    Food("披萨", "File:Vegetarian Pizza.jpg"),
-    Food("炸鸡", "File:Fried-Chicken-Set.jpg"),
-    Food("轻食沙拉", "File:Healthy Green Salad.JPG"),
-    Food("意大利面", "File:Spaghetti bolognese.jpg"),
-    Food("牛排", "File:Steak-frites (steak-and-chips).jpg"),
-    Food("三明治", "File:Classic Club Sandwich, Dôme East Fremantle, 2026 (02).jpg"),
-    Food("墨西哥卷饼", "File:(20251114) Chicken burrito 01.jpg"),
-    Food("薯条", "File:French Fries.JPG"),
-    Food("热狗", "File:Hot dog with mustard.png"),
+def process_data(data: object) -> tuple[Food, ...]:
+    """校验并展开按菜系分类的美食数据。"""
+    if not isinstance(data, dict) or data.get("version") != 1:
+        raise ValueError("不支持的美食数据格式")
+
+    categories = data.get("categories")
+    if not isinstance(categories, list) or not categories:
+        raise ValueError("美食数据中没有分类")
+
+    foods: list[Food] = []
+    for category in categories:
+        if not isinstance(category, dict) or not isinstance(category.get("name"), str):
+            raise ValueError("美食分类格式错误")
+        category_foods = category.get("foods")
+        if not isinstance(category_foods, list) or not category_foods:
+            raise ValueError(f"美食分类 {category['name']} 为空")
+        for item in category_foods:
+            if not isinstance(item, dict):
+                raise ValueError("美食条目格式错误")
+            name = item.get("name")
+            commons_file = item.get("commons_file")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError("美食名称不能为空")
+            if not isinstance(commons_file, str) or not commons_file.startswith("File:"):
+                raise ValueError(f"美食 {name} 的 Wikimedia Commons 文件名无效")
+            foods.append(Food(name=name, commons_file=commons_file))
+
+    if len({food.name for food in foods}) != len(foods):
+        raise ValueError("美食名称不能重复")
+    if len({food.commons_file for food in foods}) != len(foods):
+        raise ValueError("Wikimedia Commons 文件名不能重复")
+    return tuple(foods)
+
+
+FOODS_DATA = RemoteJsonData(
+    FOODS_DATA_URL,
+    lambda: get_cache_file("what_to_eat", "foods.json"),
+    process_data,
 )
 
 
-def recommend_food() -> Food:
-    """随机选择一种美食。"""
-    return choice(FOODS)
+async def recommend_food() -> Food:
+    """从已缓存的远程数据中随机选择一种美食。"""
+    foods = await FOODS_DATA.data
+    return choice(foods)

--- a/src/plugins/what_to_eat/data_source.py
+++ b/src/plugins/what_to_eat/data_source.py
@@ -1,6 +1,7 @@
 """随机美食推荐数据。"""
 
 from dataclasses import dataclass
+from datetime import date
 from random import choice
 
 from nonebot_plugin_localstore import get_cache_file
@@ -18,10 +19,28 @@ class Food:
     commons_file: str
 
 
-def process_data(data: object) -> tuple[Food, ...]:
+@dataclass(frozen=True)
+class FoodDataset:
+    """已校验的美食数据及其发布日期。"""
+
+    version: date
+    foods: tuple[Food, ...]
+
+
+def process_data(data: object) -> FoodDataset:
     """校验并展开按菜系分类的美食数据。"""
-    if not isinstance(data, dict) or data.get("version") != 1:
+    if not isinstance(data, dict):
         raise ValueError("不支持的美食数据格式")
+
+    version = data.get("version")
+    if not isinstance(version, str):
+        raise ValueError("美食数据版本必须是日期")
+    try:
+        version_date = date.fromisoformat(version)
+    except ValueError as e:
+        raise ValueError("美食数据版本必须是 YYYY-MM-DD 格式的日期") from e
+    if version_date.isoformat() != version:
+        raise ValueError("美食数据版本必须是 YYYY-MM-DD 格式的日期")
 
     categories = data.get("categories")
     if not isinstance(categories, list) or not categories:
@@ -49,7 +68,7 @@ def process_data(data: object) -> tuple[Food, ...]:
         raise ValueError("美食名称不能重复")
     if len({food.commons_file for food in foods}) != len(foods):
         raise ValueError("Wikimedia Commons 文件名不能重复")
-    return tuple(foods)
+    return FoodDataset(version=version_date, foods=tuple(foods))
 
 
 FOODS_DATA = RemoteJsonData(
@@ -61,5 +80,5 @@ FOODS_DATA = RemoteJsonData(
 
 async def recommend_food() -> Food:
     """从已缓存的远程数据中随机选择一种美食。"""
-    foods = await FOODS_DATA.data
-    return choice(foods)
+    dataset = await FOODS_DATA.data
+    return choice(dataset.foods)

--- a/src/plugins/what_to_eat/data_source.py
+++ b/src/plugins/what_to_eat/data_source.py
@@ -3,6 +3,8 @@
 from dataclasses import dataclass
 from datetime import date
 from random import choice
+from typing import Literal
+from uuid import UUID
 
 from nonebot_plugin_localstore import get_plugin_cache_dir
 
@@ -10,13 +12,28 @@ from src.utils.remote_data import RemoteJsonData
 
 FOODS_DATA_URL = "https://bot-docs.hehome.xyz/foods.json"
 
+type FoodImageProvider = Literal["commons", "openverse"]
+
+
+@dataclass(frozen=True)
+class FoodImageRef:
+    """人工挑选的图片来源及其稳定标识。"""
+
+    provider: FoodImageProvider
+    id: str
+
+    @property
+    def cache_key(self) -> str:
+        """生成跨图片来源唯一的缓存键。"""
+        return f"{self.provider}:{self.id}"
+
 
 @dataclass(frozen=True)
 class Food:
-    """美食名称及人工挑选的 Wikimedia Commons 文件。"""
+    """美食名称及人工挑选的图片。"""
 
     name: str
-    commons_file: str
+    image: FoodImageRef
 
 
 @dataclass(frozen=True)
@@ -25,6 +42,30 @@ class FoodDataset:
 
     version: date
     foods: tuple[Food, ...]
+
+
+def _parse_image_ref(item: dict[str, object], food_name: str) -> FoodImageRef:
+    image = item.get("image")
+    if not isinstance(image, dict):
+        raise ValueError(f"美食 {food_name} 的图片格式错误")
+
+    provider = image.get("provider")
+    image_id = image.get("id")
+    if not isinstance(image_id, str) or not image_id:
+        raise ValueError(f"美食 {food_name} 的图片来源或标识无效")
+    if provider == "commons":
+        if not image_id.startswith("File:"):
+            raise ValueError(f"美食 {food_name} 的 Wikimedia Commons 文件名无效")
+        return FoodImageRef(provider="commons", id=image_id)
+    if provider == "openverse":
+        try:
+            parsed_id = UUID(image_id)
+        except ValueError as e:
+            raise ValueError(f"美食 {food_name} 的 Openverse 图片 ID 无效") from e
+        if str(parsed_id) != image_id:
+            raise ValueError(f"美食 {food_name} 的 Openverse 图片 ID 无效")
+        return FoodImageRef(provider="openverse", id=image_id)
+    raise ValueError(f"美食 {food_name} 的图片来源或标识无效")
 
 
 def process_data(data: object) -> FoodDataset:
@@ -57,17 +98,14 @@ def process_data(data: object) -> FoodDataset:
             if not isinstance(item, dict):
                 raise ValueError("美食条目格式错误")
             name = item.get("name")
-            commons_file = item.get("commons_file")
             if not isinstance(name, str) or not name.strip():
                 raise ValueError("美食名称不能为空")
-            if not isinstance(commons_file, str) or not commons_file.startswith("File:"):
-                raise ValueError(f"美食 {name} 的 Wikimedia Commons 文件名无效")
-            foods.append(Food(name=name, commons_file=commons_file))
+            foods.append(Food(name=name, image=_parse_image_ref(item, name)))
 
     if len({food.name for food in foods}) != len(foods):
         raise ValueError("美食名称不能重复")
-    if len({food.commons_file for food in foods}) != len(foods):
-        raise ValueError("Wikimedia Commons 文件名不能重复")
+    if len({food.image.cache_key for food in foods}) != len(foods):
+        raise ValueError("美食图片不能重复")
     return FoodDataset(version=version_date, foods=tuple(foods))
 
 

--- a/src/plugins/what_to_eat/data_source.py
+++ b/src/plugins/what_to_eat/data_source.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import date
 from random import choice
 
-from nonebot_plugin_localstore import get_cache_file
+from nonebot_plugin_localstore import get_plugin_cache_dir
 
 from src.utils.remote_data import RemoteJsonData
 
@@ -73,7 +73,7 @@ def process_data(data: object) -> FoodDataset:
 
 FOODS_DATA = RemoteJsonData(
     FOODS_DATA_URL,
-    lambda: get_cache_file("what_to_eat", "foods.json"),
+    lambda: get_plugin_cache_dir() / "foods.json",
     process_data,
 )
 

--- a/src/plugins/what_to_eat/image_api.py
+++ b/src/plugins/what_to_eat/image_api.py
@@ -1,4 +1,4 @@
-"""从 Wikimedia Commons 获取带授权信息的美食图片。"""
+"""从受支持的开放图片来源获取带授权信息的美食图片。"""
 
 import asyncio
 import contextlib
@@ -18,18 +18,29 @@ from nonebot_plugin_localstore import get_plugin_cache_dir
 
 from src.utils.files import write_bytes_atomic
 
+from .data_source import FoodImageRef
+
 COMMONS_API_URL = "https://commons.wikimedia.org/w/api.php"
-COMMONS_USER_AGENT = "CoolQBot (+https://github.com/he0119/CoolQBot)"
+OPENVERSE_API_URL = "https://api.openverse.org/v1/images"
+IMAGE_USER_AGENT = "CoolQBot (+https://github.com/he0119/CoolQBot)"
 COMMONS_THUMBNAIL_HOST = "upload.wikimedia.org"
 COMMONS_PAGE_HOST = "commons.wikimedia.org"
+OPENVERSE_API_HOST = "api.openverse.org"
 COMMONS_IMAGE_WIDTH = 640
 MAX_IMAGE_BYTES = 3 * 1024 * 1024
 IMAGE_CACHE_SIZE = 32
-IMAGE_DISK_CACHE_VERSION = 1
+IMAGE_DISK_CACHE_VERSION = 2
 SUPPORTED_IMAGE_TYPES = {"image/gif", "image/jpeg", "image/png", "image/webp"}
 SAFE_LICENSE_HOSTS = {"commons.wikimedia.org", "creativecommons.org", "www.gnu.org"}
+OPENVERSE_LICENSE_NAMES = {
+    "by": "CC BY",
+    "by-sa": "CC BY-SA",
+    "cc0": "CC0",
+    "pdm": "Public Domain Mark",
+}
 
 _HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
+_LICENSE_VERSION_PATTERN = re.compile(r"\d+(?:\.\d+)?")
 _IMAGE_CACHE: OrderedDict[str, "FoodImage"] = OrderedDict()
 _IMAGE_LOCKS: dict[str, asyncio.Lock] = {}
 
@@ -54,6 +65,16 @@ class FoodImage:
         return "\n".join(lines)
 
 
+@dataclass(frozen=True)
+class _ResolvedImage:
+    thumbnail_url: str
+    expected_mimetype: str | None
+    creator: str
+    license_name: str
+    source_url: str
+    license_url: str | None
+
+
 def _plain_text(value: object, default: str, max_length: int) -> str:
     if not isinstance(value, str):
         return default
@@ -71,11 +92,17 @@ def _metadata_value(metadata: object, key: str) -> str | None:
     return value if isinstance(value, str) else None
 
 
-def _is_https_url(url: object, allowed_hosts: set[str]) -> TypeGuard[str]:
-    if not isinstance(url, str):
+def _is_https_url(url: object, allowed_hosts: set[str] | None = None) -> TypeGuard[str]:
+    if not isinstance(url, str) or len(url) > 2048:
         return False
     parsed = urlparse(url)
-    return parsed.scheme == "https" and parsed.hostname in allowed_hosts and not parsed.username and not parsed.password
+    return (
+        parsed.scheme == "https"
+        and parsed.hostname is not None
+        and (allowed_hosts is None or parsed.hostname in allowed_hosts)
+        and not parsed.username
+        and not parsed.password
+    )
 
 
 def _safe_license_url(value: str | None) -> str | None:
@@ -85,7 +112,7 @@ def _safe_license_url(value: str | None) -> str | None:
     return url if _is_https_url(url, SAFE_LICENSE_HOSTS) else None
 
 
-def _parse_file_result(payload: object) -> tuple[str, str, str, str, str, str | None] | None:
+def _parse_commons_result(payload: object) -> _ResolvedImage | None:
     if not isinstance(payload, dict):
         return None
     query = payload.get("query")
@@ -115,10 +142,66 @@ def _parse_file_result(payload: object) -> tuple[str, str, str, str, str, str | 
             continue
 
         metadata = info.get("extmetadata")
-        creator = _plain_text(_metadata_value(metadata, "Artist"), "未知作者", 100)
-        license_name = _plain_text(_metadata_value(metadata, "LicenseShortName"), "授权信息见来源页", 60)
-        license_url = _safe_license_url(_metadata_value(metadata, "LicenseUrl"))
-        return thumbnail_url, mimetype, creator, license_name, source_url, license_url
+        return _ResolvedImage(
+            thumbnail_url=thumbnail_url,
+            expected_mimetype=mimetype,
+            creator=_plain_text(_metadata_value(metadata, "Artist"), "未知作者", 100),
+            license_name=_plain_text(_metadata_value(metadata, "LicenseShortName"), "授权信息见来源页", 60),
+            source_url=source_url,
+            license_url=_safe_license_url(_metadata_value(metadata, "LicenseUrl")),
+        )
+    return None
+
+
+def _parse_openverse_result(payload: object, image_id: str) -> _ResolvedImage | None:
+    if not isinstance(payload, dict) or payload.get("id") != image_id:
+        return None
+
+    license_code = payload.get("license")
+    license_version = payload.get("license_version")
+    license_url = payload.get("license_url")
+    source_url = payload.get("foreign_landing_url")
+    if not isinstance(license_code, str) or license_code not in OPENVERSE_LICENSE_NAMES:
+        return None
+    if not isinstance(license_version, str) or not _LICENSE_VERSION_PATTERN.fullmatch(license_version):
+        return None
+    if not _is_https_url(license_url, {"creativecommons.org"}):
+        return None
+    if not _is_https_url(source_url):
+        return None
+
+    thumbnail_url = f"{OPENVERSE_API_URL}/{image_id}/thumb/"
+    if not _is_https_url(thumbnail_url, {OPENVERSE_API_HOST}):
+        return None
+    return _ResolvedImage(
+        thumbnail_url=thumbnail_url,
+        expected_mimetype=None,
+        creator=_plain_text(payload.get("creator"), "未知作者", 100),
+        license_name=f"{OPENVERSE_LICENSE_NAMES[license_code]} {license_version}",
+        source_url=source_url,
+        license_url=license_url,
+    )
+
+
+async def _resolve_image(client: httpx.AsyncClient, source: FoodImageRef) -> _ResolvedImage | None:
+    if source.provider == "commons":
+        params = {
+            "action": "query",
+            "titles": source.id,
+            "redirects": 1,
+            "prop": "imageinfo",
+            "iiprop": "url|mime|extmetadata",
+            "iiurlwidth": COMMONS_IMAGE_WIDTH,
+            "format": "json",
+            "formatversion": 2,
+        }
+        response = await client.get(COMMONS_API_URL, params=params)
+        response.raise_for_status()
+        return _parse_commons_result(response.json())
+    if source.provider == "openverse":
+        response = await client.get(f"{OPENVERSE_API_URL}/{source.id}/")
+        response.raise_for_status()
+        return _parse_openverse_result(response.json(), source.id)
     return None
 
 
@@ -141,15 +224,15 @@ async def _download_image(client: httpx.AsyncClient, url: str) -> tuple[bytes, s
         return (bytes(content), mimetype) if content else None
 
 
-def _cache_image(file_title: str, image: FoodImage) -> None:
-    _IMAGE_CACHE[file_title] = image
-    _IMAGE_CACHE.move_to_end(file_title)
+def _cache_image(cache_key: str, image: FoodImage) -> None:
+    _IMAGE_CACHE[cache_key] = image
+    _IMAGE_CACHE.move_to_end(cache_key)
     while len(_IMAGE_CACHE) > IMAGE_CACHE_SIZE:
         _IMAGE_CACHE.popitem(last=False)
 
 
-def _disk_cache_paths(file_title: str) -> tuple[Path, Path]:
-    digest = sha256(file_title.encode()).hexdigest()
+def _disk_cache_paths(source: FoodImageRef) -> tuple[Path, Path]:
+    digest = sha256(source.cache_key.encode()).hexdigest()
     cache_dir = get_plugin_cache_dir() / "images"
     return cache_dir / f"{digest}.json", cache_dir / f"{digest}.image"
 
@@ -161,8 +244,14 @@ def _discard_disk_cache(metadata_file: Path, image_file: Path) -> None:
         image_file.unlink(missing_ok=True)
 
 
-def _load_disk_image(file_title: str) -> FoodImage | None:
-    metadata_file, image_file = _disk_cache_paths(file_title)
+def _is_valid_source_url(source: FoodImageRef, source_url: str) -> bool:
+    if source.provider == "commons":
+        return _is_https_url(source_url, {COMMONS_PAGE_HOST})
+    return source.provider == "openverse" and _is_https_url(source_url)
+
+
+def _load_disk_image(source: FoodImageRef) -> FoodImage | None:
+    metadata_file, image_file = _disk_cache_paths(source)
     if not metadata_file.is_file() or not image_file.is_file():
         _discard_disk_cache(metadata_file, image_file)
         return None
@@ -171,8 +260,12 @@ def _load_disk_image(file_title: str) -> FoodImage | None:
         metadata = json.loads(metadata_file.read_bytes())
         if not isinstance(metadata, dict):
             raise ValueError("缓存元数据不是对象")
-        if metadata.get("version") != IMAGE_DISK_CACHE_VERSION or metadata.get("file_title") != file_title:
-            raise ValueError("缓存版本或文件标题不匹配")
+        if (
+            metadata.get("version") != IMAGE_DISK_CACHE_VERSION
+            or metadata.get("provider") != source.provider
+            or metadata.get("id") != source.id
+        ):
+            raise ValueError("缓存版本或图片标识不匹配")
 
         mimetype = metadata.get("mimetype")
         creator = metadata.get("creator")
@@ -187,7 +280,7 @@ def _load_disk_image(file_title: str) -> FoodImage | None:
             raise ValueError("缓存作者信息无效")
         if not isinstance(license_name, str) or not license_name or len(license_name) > 60:
             raise ValueError("缓存许可名称无效")
-        if not _is_https_url(source_url, {COMMONS_PAGE_HOST}):
+        if not isinstance(source_url, str) or not _is_valid_source_url(source, source_url):
             raise ValueError("缓存来源地址无效")
         if license_url is not None and not _is_https_url(license_url, SAFE_LICENSE_HOSTS):
             raise ValueError("缓存许可地址无效")
@@ -208,16 +301,22 @@ def _load_disk_image(file_title: str) -> FoodImage | None:
             license_url=license_url,
         )
     except (json.JSONDecodeError, OSError, TypeError, ValueError) as e:
-        logger.warning("Commons 本地图片缓存损坏，将重新下载：文件={}，原因={}", file_title, e)
+        logger.warning(
+            "美食图片本地缓存损坏，将重新下载：来源={}，ID={}，原因={}",
+            source.provider,
+            source.id,
+            e,
+        )
         _discard_disk_cache(metadata_file, image_file)
         return None
 
 
-def _store_disk_image(file_title: str, image: FoodImage) -> None:
-    metadata_file, image_file = _disk_cache_paths(file_title)
+def _store_disk_image(source: FoodImageRef, image: FoodImage) -> None:
+    metadata_file, image_file = _disk_cache_paths(source)
     metadata = {
         "version": IMAGE_DISK_CACHE_VERSION,
-        "file_title": file_title,
+        "provider": source.provider,
+        "id": source.id,
         "mimetype": image.mimetype,
         "creator": image.creator,
         "license_name": image.license_name,
@@ -230,64 +329,62 @@ def _store_disk_image(file_title: str, image: FoodImage) -> None:
     write_bytes_atomic(metadata_file, json.dumps(metadata, ensure_ascii=False, separators=(",", ":")).encode())
 
 
-async def get_food_image(file_title: str) -> FoodImage | None:
-    """按文件标题获取一张 Wikimedia Commons 美食缩略图。"""
-    if cached := _IMAGE_CACHE.get(file_title):
-        _IMAGE_CACHE.move_to_end(file_title)
+async def get_food_image(source: FoodImageRef) -> FoodImage | None:
+    """按人工指定的来源和 ID 获取一张美食缩略图。"""
+    cache_key = source.cache_key
+    if cached := _IMAGE_CACHE.get(cache_key):
+        _IMAGE_CACHE.move_to_end(cache_key)
         return cached
 
-    lock = _IMAGE_LOCKS.setdefault(file_title, asyncio.Lock())
+    lock = _IMAGE_LOCKS.setdefault(cache_key, asyncio.Lock())
     async with lock:
-        if cached := _IMAGE_CACHE.get(file_title):
-            _IMAGE_CACHE.move_to_end(file_title)
+        if cached := _IMAGE_CACHE.get(cache_key):
+            _IMAGE_CACHE.move_to_end(cache_key)
             return cached
-        if cached := _load_disk_image(file_title):
-            _cache_image(file_title, cached)
+        if cached := _load_disk_image(source):
+            _cache_image(cache_key, cached)
             return cached
 
-        params = {
-            "action": "query",
-            "titles": file_title,
-            "redirects": 1,
-            "prop": "imageinfo",
-            "iiprop": "url|mime|extmetadata",
-            "iiurlwidth": COMMONS_IMAGE_WIDTH,
-            "format": "json",
-            "formatversion": 2,
-        }
         try:
             async with httpx.AsyncClient(
-                headers={"User-Agent": COMMONS_USER_AGENT},
+                headers={"User-Agent": IMAGE_USER_AGENT},
                 timeout=10,
                 follow_redirects=False,
             ) as client:
-                response = await client.get(COMMONS_API_URL, params=params)
-                response.raise_for_status()
-                result = _parse_file_result(response.json())
-                if not result:
+                resolved = await _resolve_image(client, source)
+                if not resolved:
                     return None
-                thumbnail_url, expected_mimetype, creator, license_name, source_url, license_url = result
-                downloaded = await _download_image(client, thumbnail_url)
+                downloaded = await _download_image(client, resolved.thumbnail_url)
                 if not downloaded:
                     return None
                 content, mimetype = downloaded
-                if mimetype != expected_mimetype:
-                    logger.debug("Commons 美食图片格式与元数据不同：文件={}，实际格式={}", file_title, mimetype)
+                if resolved.expected_mimetype and mimetype != resolved.expected_mimetype:
+                    logger.debug(
+                        "美食图片格式与元数据不同：来源={}，ID={}，实际格式={}",
+                        source.provider,
+                        source.id,
+                        mimetype,
+                    )
                 image = FoodImage(
                     content=content,
                     mimetype=mimetype,
-                    creator=creator,
-                    license_name=license_name,
-                    source_url=source_url,
-                    license_url=license_url,
+                    creator=resolved.creator,
+                    license_name=resolved.license_name,
+                    source_url=resolved.source_url,
+                    license_url=resolved.license_url,
                 )
         except (httpx.HTTPError, KeyError, TypeError, ValueError):
-            logger.warning("Commons 美食图片获取失败：文件={}，回退为纯文字", file_title)
+            logger.warning("美食图片获取失败：来源={}，ID={}，回退为纯文字", source.provider, source.id)
             return None
 
         try:
-            _store_disk_image(file_title, image)
+            _store_disk_image(source, image)
         except OSError as e:
-            logger.warning("Commons 美食图片写入本地缓存失败：文件={}，原因={}", file_title, e)
-        _cache_image(file_title, image)
+            logger.warning(
+                "美食图片写入本地缓存失败：来源={}，ID={}，原因={}",
+                source.provider,
+                source.id,
+                e,
+            )
+        _cache_image(cache_key, image)
         return image

--- a/src/plugins/what_to_eat/image_api.py
+++ b/src/plugins/what_to_eat/image_api.py
@@ -1,14 +1,22 @@
 """从 Wikimedia Commons 获取带授权信息的美食图片。"""
 
+import asyncio
+import contextlib
 import html
+import json
 import re
 from collections import OrderedDict
 from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
 from typing import TypeGuard
 from urllib.parse import urljoin, urlparse
 
 import httpx
 from nonebot import logger
+from nonebot_plugin_localstore import get_plugin_cache_dir
+
+from src.utils.files import write_bytes_atomic
 
 COMMONS_API_URL = "https://commons.wikimedia.org/w/api.php"
 COMMONS_USER_AGENT = "CoolQBot (+https://github.com/he0119/CoolQBot)"
@@ -17,11 +25,13 @@ COMMONS_PAGE_HOST = "commons.wikimedia.org"
 COMMONS_IMAGE_WIDTH = 640
 MAX_IMAGE_BYTES = 3 * 1024 * 1024
 IMAGE_CACHE_SIZE = 32
+IMAGE_DISK_CACHE_VERSION = 1
 SUPPORTED_IMAGE_TYPES = {"image/gif", "image/jpeg", "image/png", "image/webp"}
 SAFE_LICENSE_HOSTS = {"commons.wikimedia.org", "creativecommons.org", "www.gnu.org"}
 
 _HTML_TAG_PATTERN = re.compile(r"<[^>]+>")
 _IMAGE_CACHE: OrderedDict[str, "FoodImage"] = OrderedDict()
+_IMAGE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 @dataclass(frozen=True)
@@ -128,7 +138,7 @@ async def _download_image(client: httpx.AsyncClient, url: str) -> tuple[bytes, s
             content.extend(chunk)
             if len(content) > MAX_IMAGE_BYTES:
                 return None
-        return bytes(content), mimetype
+        return (bytes(content), mimetype) if content else None
 
 
 def _cache_image(file_title: str, image: FoodImage) -> None:
@@ -138,51 +148,146 @@ def _cache_image(file_title: str, image: FoodImage) -> None:
         _IMAGE_CACHE.popitem(last=False)
 
 
+def _disk_cache_paths(file_title: str) -> tuple[Path, Path]:
+    digest = sha256(file_title.encode()).hexdigest()
+    cache_dir = get_plugin_cache_dir() / "images"
+    return cache_dir / f"{digest}.json", cache_dir / f"{digest}.image"
+
+
+def _discard_disk_cache(metadata_file: Path, image_file: Path) -> None:
+    with contextlib.suppress(OSError):
+        metadata_file.unlink(missing_ok=True)
+    with contextlib.suppress(OSError):
+        image_file.unlink(missing_ok=True)
+
+
+def _load_disk_image(file_title: str) -> FoodImage | None:
+    metadata_file, image_file = _disk_cache_paths(file_title)
+    if not metadata_file.is_file() or not image_file.is_file():
+        _discard_disk_cache(metadata_file, image_file)
+        return None
+
+    try:
+        metadata = json.loads(metadata_file.read_bytes())
+        if not isinstance(metadata, dict):
+            raise ValueError("缓存元数据不是对象")
+        if metadata.get("version") != IMAGE_DISK_CACHE_VERSION or metadata.get("file_title") != file_title:
+            raise ValueError("缓存版本或文件标题不匹配")
+
+        mimetype = metadata.get("mimetype")
+        creator = metadata.get("creator")
+        license_name = metadata.get("license_name")
+        source_url = metadata.get("source_url")
+        license_url = metadata.get("license_url")
+        size = metadata.get("size")
+        content_hash = metadata.get("sha256")
+        if mimetype not in SUPPORTED_IMAGE_TYPES:
+            raise ValueError("缓存图片格式无效")
+        if not isinstance(creator, str) or not creator or len(creator) > 100:
+            raise ValueError("缓存作者信息无效")
+        if not isinstance(license_name, str) or not license_name or len(license_name) > 60:
+            raise ValueError("缓存许可名称无效")
+        if not _is_https_url(source_url, {COMMONS_PAGE_HOST}):
+            raise ValueError("缓存来源地址无效")
+        if license_url is not None and not _is_https_url(license_url, SAFE_LICENSE_HOSTS):
+            raise ValueError("缓存许可地址无效")
+        if not isinstance(size, int) or not 0 < size <= MAX_IMAGE_BYTES:
+            raise ValueError("缓存图片大小无效")
+        if not isinstance(content_hash, str) or len(content_hash) != 64:
+            raise ValueError("缓存图片哈希无效")
+
+        content = image_file.read_bytes()
+        if len(content) != size or sha256(content).hexdigest() != content_hash:
+            raise ValueError("缓存图片内容不完整")
+        return FoodImage(
+            content=content,
+            mimetype=mimetype,
+            creator=creator,
+            license_name=license_name,
+            source_url=source_url,
+            license_url=license_url,
+        )
+    except (json.JSONDecodeError, OSError, TypeError, ValueError) as e:
+        logger.warning("Commons 本地图片缓存损坏，将重新下载：文件={}，原因={}", file_title, e)
+        _discard_disk_cache(metadata_file, image_file)
+        return None
+
+
+def _store_disk_image(file_title: str, image: FoodImage) -> None:
+    metadata_file, image_file = _disk_cache_paths(file_title)
+    metadata = {
+        "version": IMAGE_DISK_CACHE_VERSION,
+        "file_title": file_title,
+        "mimetype": image.mimetype,
+        "creator": image.creator,
+        "license_name": image.license_name,
+        "source_url": image.source_url,
+        "license_url": image.license_url,
+        "size": len(image.content),
+        "sha256": sha256(image.content).hexdigest(),
+    }
+    write_bytes_atomic(image_file, image.content)
+    write_bytes_atomic(metadata_file, json.dumps(metadata, ensure_ascii=False, separators=(",", ":")).encode())
+
+
 async def get_food_image(file_title: str) -> FoodImage | None:
-    """按文件标题下载一张 Wikimedia Commons 美食缩略图。"""
+    """按文件标题获取一张 Wikimedia Commons 美食缩略图。"""
     if cached := _IMAGE_CACHE.get(file_title):
         _IMAGE_CACHE.move_to_end(file_title)
         return cached
 
-    params = {
-        "action": "query",
-        "titles": file_title,
-        "redirects": 1,
-        "prop": "imageinfo",
-        "iiprop": "url|mime|extmetadata",
-        "iiurlwidth": COMMONS_IMAGE_WIDTH,
-        "format": "json",
-        "formatversion": 2,
-    }
-    try:
-        async with httpx.AsyncClient(
-            headers={"User-Agent": COMMONS_USER_AGENT},
-            timeout=10,
-            follow_redirects=False,
-        ) as client:
-            response = await client.get(COMMONS_API_URL, params=params)
-            response.raise_for_status()
-            result = _parse_file_result(response.json())
-            if not result:
-                return None
-            thumbnail_url, expected_mimetype, creator, license_name, source_url, license_url = result
-            downloaded = await _download_image(client, thumbnail_url)
-            if not downloaded:
-                return None
-            content, mimetype = downloaded
-            if mimetype != expected_mimetype:
-                logger.debug("Commons 美食图片格式与元数据不同：文件={}，实际格式={}", file_title, mimetype)
-            image = FoodImage(
-                content=content,
-                mimetype=mimetype,
-                creator=creator,
-                license_name=license_name,
-                source_url=source_url,
-                license_url=license_url,
-            )
-    except (httpx.HTTPError, KeyError, TypeError, ValueError):
-        logger.warning("Commons 美食图片获取失败：文件={}，回退为纯文字", file_title)
-        return None
+    lock = _IMAGE_LOCKS.setdefault(file_title, asyncio.Lock())
+    async with lock:
+        if cached := _IMAGE_CACHE.get(file_title):
+            _IMAGE_CACHE.move_to_end(file_title)
+            return cached
+        if cached := _load_disk_image(file_title):
+            _cache_image(file_title, cached)
+            return cached
 
-    _cache_image(file_title, image)
-    return image
+        params = {
+            "action": "query",
+            "titles": file_title,
+            "redirects": 1,
+            "prop": "imageinfo",
+            "iiprop": "url|mime|extmetadata",
+            "iiurlwidth": COMMONS_IMAGE_WIDTH,
+            "format": "json",
+            "formatversion": 2,
+        }
+        try:
+            async with httpx.AsyncClient(
+                headers={"User-Agent": COMMONS_USER_AGENT},
+                timeout=10,
+                follow_redirects=False,
+            ) as client:
+                response = await client.get(COMMONS_API_URL, params=params)
+                response.raise_for_status()
+                result = _parse_file_result(response.json())
+                if not result:
+                    return None
+                thumbnail_url, expected_mimetype, creator, license_name, source_url, license_url = result
+                downloaded = await _download_image(client, thumbnail_url)
+                if not downloaded:
+                    return None
+                content, mimetype = downloaded
+                if mimetype != expected_mimetype:
+                    logger.debug("Commons 美食图片格式与元数据不同：文件={}，实际格式={}", file_title, mimetype)
+                image = FoodImage(
+                    content=content,
+                    mimetype=mimetype,
+                    creator=creator,
+                    license_name=license_name,
+                    source_url=source_url,
+                    license_url=license_url,
+                )
+        except (httpx.HTTPError, KeyError, TypeError, ValueError):
+            logger.warning("Commons 美食图片获取失败：文件={}，回退为纯文字", file_title)
+            return None
+
+        try:
+            _store_disk_image(file_title, image)
+        except OSError as e:
+            logger.warning("Commons 美食图片写入本地缓存失败：文件={}，原因={}", file_title, e)
+        _cache_image(file_title, image)
+        return image

--- a/src/utils/files.py
+++ b/src/utils/files.py
@@ -1,0 +1,21 @@
+"""文件操作工具。"""
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def write_bytes_atomic(file: Path, content: bytes) -> None:
+    """在同一目录写入临时文件，再原子替换目标文件。"""
+    file.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(dir=file.parent, prefix=f".{file.name}.", delete=False) as f:
+            temporary_path = Path(f.name)
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        temporary_path.replace(file)
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)

--- a/src/utils/remote_data.py
+++ b/src/utils/remote_data.py
@@ -1,0 +1,147 @@
+"""带本地缓存的远程 JSON 数据。"""
+
+import asyncio
+import json
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import httpx
+from nonebot.log import logger
+
+DEFAULT_MAX_BYTES = 1024 * 1024
+DEFAULT_USER_AGENT = "CoolQBot (+https://github.com/he0119/CoolQBot)"
+_UNSET = object()
+
+
+class RemoteDataError(RuntimeError):
+    """远程数据读取或校验失败。"""
+
+
+class RemoteDataTooLargeError(RemoteDataError):
+    """远程数据超过大小限制。"""
+
+
+class RemoteJsonData[T]:
+    """下载、校验并原子缓存远程 JSON 数据。
+
+    首次读取优先使用本地缓存；缓存不存在或损坏时才访问网络。显式调用
+    :meth:`update` 会强制下载，但只有在 HTTP、JSON 解析和业务校验全部成功后
+    才替换内存及磁盘缓存。
+    """
+
+    def __init__(
+        self,
+        url: str,
+        cache_file: Callable[[], Path],
+        process_data: Callable[[Any], T],
+        *,
+        max_bytes: int = DEFAULT_MAX_BYTES,
+        timeout: float = 10.0,
+    ) -> None:
+        if max_bytes <= 0:
+            raise ValueError("max_bytes 必须大于 0")
+
+        self.url = url
+        self._cache_file = cache_file
+        self._process_data = process_data
+        self._max_bytes = max_bytes
+        self._timeout = timeout
+        self._data: T | object = _UNSET
+        self._lock = asyncio.Lock()
+
+    @property
+    def cache_file(self) -> Path:
+        """当前配置对应的缓存文件路径。"""
+        return self._cache_file()
+
+    @property
+    async def data(self) -> T:
+        """读取内存或磁盘缓存，必要时从网络初始化。"""
+        if self._data is not _UNSET:
+            return self._data  # type: ignore[return-value]
+
+        async with self._lock:
+            if self._data is not _UNSET:
+                return self._data  # type: ignore[return-value]
+
+            cache_file = self.cache_file
+            if cache_file.is_file():
+                try:
+                    data = self._load_local(cache_file)
+                except Exception as e:
+                    logger.warning("本地远程数据缓存损坏，将重新下载 {}: {}", cache_file, e)
+                else:
+                    self._data = data
+                    return data
+
+            return await self._update_locked()
+
+    async def update(self) -> T:
+        """强制刷新数据；失败时保留原内存和磁盘缓存。"""
+        async with self._lock:
+            return await self._update_locked()
+
+    def clear_memory_cache(self) -> None:
+        """清除内存缓存，使下次读取重新检查磁盘。"""
+        self._data = _UNSET
+
+    def _load_local(self, cache_file: Path) -> T:
+        content = cache_file.read_bytes()
+        self._check_size(len(content))
+        return self._process_data(json.loads(content))
+
+    async def _update_locked(self) -> T:
+        cache_file = self.cache_file
+        try:
+            content = await self._download()
+            data = self._process_data(json.loads(content))
+            self._write_atomic(cache_file, content)
+        except RemoteDataError:
+            raise
+        except Exception as e:
+            raise RemoteDataError(f"更新远程数据失败：{e}") from e
+
+        self._data = data
+        logger.info("已更新远程数据缓存 {} -> {}", self.url, cache_file)
+        return data
+
+    async def _download(self) -> bytes:
+        headers = {"User-Agent": DEFAULT_USER_AGENT}
+        async with (
+            httpx.AsyncClient(timeout=self._timeout, follow_redirects=True, headers=headers) as client,
+            client.stream("GET", self.url) as response,
+        ):
+            response.raise_for_status()
+            if content_length := response.headers.get("Content-Length"):
+                try:
+                    self._check_size(int(content_length))
+                except ValueError as e:
+                    raise RemoteDataError("远程数据的 Content-Length 无效") from e
+
+            content = bytearray()
+            async for chunk in response.aiter_bytes():
+                content.extend(chunk)
+                self._check_size(len(content))
+            return bytes(content)
+
+    def _check_size(self, size: int) -> None:
+        if size > self._max_bytes:
+            raise RemoteDataTooLargeError(f"远程数据超过 {self._max_bytes} 字节限制")
+
+    @staticmethod
+    def _write_atomic(cache_file: Path, content: bytes) -> None:
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=cache_file.parent, prefix=f".{cache_file.name}.", delete=False) as f:
+                temporary_path = Path(f.name)
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            temporary_path.replace(cache_file)
+        finally:
+            if temporary_path is not None:
+                temporary_path.unlink(missing_ok=True)

--- a/src/utils/remote_data.py
+++ b/src/utils/remote_data.py
@@ -2,14 +2,14 @@
 
 import asyncio
 import json
-import os
-import tempfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import httpx
 from nonebot.log import logger
+
+from src.utils.files import write_bytes_atomic
 
 DEFAULT_MAX_BYTES = 1024 * 1024
 DEFAULT_USER_AGENT = "CoolQBot (+https://github.com/he0119/CoolQBot)"
@@ -98,7 +98,7 @@ class RemoteJsonData[T]:
         try:
             content = await self._download()
             data = self._process_data(json.loads(content))
-            self._write_atomic(cache_file, content)
+            write_bytes_atomic(cache_file, content)
         except RemoteDataError:
             raise
         except Exception as e:
@@ -130,18 +130,3 @@ class RemoteJsonData[T]:
     def _check_size(self, size: int) -> None:
         if size > self._max_bytes:
             raise RemoteDataTooLargeError(f"远程数据超过 {self._max_bytes} 字节限制")
-
-    @staticmethod
-    def _write_atomic(cache_file: Path, content: bytes) -> None:
-        cache_file.parent.mkdir(parents=True, exist_ok=True)
-        temporary_path: Path | None = None
-        try:
-            with tempfile.NamedTemporaryFile(dir=cache_file.parent, prefix=f".{cache_file.name}.", delete=False) as f:
-                temporary_path = Path(f.name)
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-            temporary_path.replace(cache_file)
-        finally:
-            if temporary_path is not None:
-                temporary_path.unlink(missing_ok=True)

--- a/tests/plugins/ff14/test_fflogs.py
+++ b/tests/plugins/ff14/test_fflogs.py
@@ -30,7 +30,7 @@ async def app(app: App):
         await session.execute(delete(User))
 
     # 清除缓存的数据
-    FFLOGS_DATA._data = None
+    FFLOGS_DATA.clear_memory_cache()
 
 
 @pytest.fixture
@@ -387,6 +387,23 @@ async def test_dps_update_data(
         ctx.should_finished(fflogs_cmd)
 
     assert fflogs_data_mock.call_count == 1
+
+
+async def test_dps_update_data_failure(app: App, mocker: MockerFixture):
+    from src.plugins.ff14.plugins.ff14_fflogs import FFLOGS_DATA, fflogs_cmd, plugin_config
+    from src.utils.remote_data import RemoteDataError
+
+    mocker.patch.object(plugin_config, "fflogs_token", "test")
+    mocker.patch.object(FFLOGS_DATA, "update", side_effect=RemoteDataError("unavailable"))
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter)
+        event = fake_group_message_event_v11(message=Message("/dps update"))
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "副本数据更新失败，已保留原缓存。", True)
+        ctx.should_finished(fflogs_cmd)
 
 
 @respx.mock(assert_all_called=True)

--- a/tests/plugins/ff14/test_fflogs.py
+++ b/tests/plugins/ff14/test_fflogs.py
@@ -65,6 +65,14 @@ async def fflogs_job_rankings_empty(app: App) -> dict[str, Any]:
     return data
 
 
+def test_fflogs_data_cache_path(app: App):
+    import nonebot_plugin_localstore as store
+
+    from src.plugins.ff14.plugins.ff14_fflogs.data import FFLOGS_DATA
+
+    assert FFLOGS_DATA.cache_file == store.BASE_CACHE_DIR / "ff14" / "ff14_fflogs" / "fflogs_data.json"
+
+
 async def test_dps_help(app: App, mocker: MockerFixture):
     """测试 FFLOGS，返回帮助的情况"""
     from src.plugins.ff14.plugins.ff14_fflogs import (

--- a/tests/plugins/morning/test_morning.py
+++ b/tests/plugins/morning/test_morning.py
@@ -112,6 +112,8 @@ async def test_morning_disable(app: App):
 @respx.mock
 async def test_morning_today(app: App, mocker: MockerFixture):
     """测试每日早安，查询今日早安的情况"""
+    import nonebot_plugin_localstore as store
+
     from src.plugins.morning.plugins.morning_greeting import morning_cmd
     from src.plugins.morning.plugins.morning_greeting.data_source import EXPR_MORNING, HOLIDAYS_DATA
 
@@ -138,6 +140,7 @@ async def test_morning_today(app: App, mocker: MockerFixture):
 
     mocked_date.today.assert_called()
     assert request.call_count == 1
+    assert HOLIDAYS_DATA.cache_file == store.BASE_CACHE_DIR / "morning" / "morning_greeting" / "holidays.json"
     render_expression.assert_called_once_with(
         EXPR_MORNING,
         message="今天就是元旦，好好玩吧！",

--- a/tests/plugins/morning/test_morning.py
+++ b/tests/plugins/morning/test_morning.py
@@ -2,6 +2,8 @@ import json
 from datetime import date
 from pathlib import Path
 
+import httpx
+import respx
 from nonebot import get_adapter
 from nonebot.adapters.onebot.v11 import Adapter, Bot, Message
 from nonebug import App
@@ -10,27 +12,6 @@ from pytest_mock import MockerFixture
 from sqlalchemy import select
 
 from tests.fake import fake_group_message_event_v11
-
-
-def mocked_get(url: str, **kwargs):
-    class MockResponse:
-        def __init__(self, json: dict):
-            self._json = json
-
-        def json(self):
-            return self._json
-
-        @property
-        def content(self):
-            return json.dumps(self._json).encode("utf-8")
-
-    test_dir = Path(__file__).parent
-    if url == "https://bot-docs.hehome.xyz/holidays.json":
-        with open(test_dir / "holidays.json", encoding="utf-8") as f:
-            data = json.load(f)
-        return MockResponse(data)
-
-    return MockResponse({})
 
 
 async def test_morning_enabled(app: App):
@@ -128,14 +109,17 @@ async def test_morning_disable(app: App):
         assert len(groups) == 0
 
 
+@respx.mock
 async def test_morning_today(app: App, mocker: MockerFixture):
     """测试每日早安，查询今日早安的情况"""
     from src.plugins.morning.plugins.morning_greeting import morning_cmd
-    from src.plugins.morning.plugins.morning_greeting.data_source import EXPR_MORNING
+    from src.plugins.morning.plugins.morning_greeting.data_source import EXPR_MORNING, HOLIDAYS_DATA
 
     mocked_date = mocker.patch("src.plugins.morning.plugins.morning_greeting.data_source.date")
     mocked_date.today.return_value = date(2022, 1, 1)
-    get = mocker.patch("httpx.AsyncClient.get", side_effect=mocked_get)
+    HOLIDAYS_DATA.clear_memory_cache()
+    data = json.loads((Path(__file__).parent / "holidays.json").read_text(encoding="utf-8"))
+    request = respx.get("https://bot-docs.hehome.xyz/holidays.json").mock(return_value=httpx.Response(200, json=data))
     render_expression = mocker.patch("src.plugins.morning.plugins.morning_greeting.data_source.render_expression")
     render_expression.return_value = Message("test")
 
@@ -153,11 +137,27 @@ async def test_morning_today(app: App, mocker: MockerFixture):
         ctx.should_finished(morning_cmd)
 
     mocked_date.today.assert_called()
-    get.assert_called_once_with("https://bot-docs.hehome.xyz/holidays.json")
+    assert request.call_count == 1
     render_expression.assert_called_once_with(
         EXPR_MORNING,
         message="今天就是元旦，好好玩吧！",
     )
+
+
+async def test_morning_update_failure(app: App, mocker: MockerFixture):
+    from src.plugins.morning.plugins.morning_greeting import HOLIDAYS_DATA, morning_cmd
+    from src.utils.remote_data import RemoteDataError
+
+    mocker.patch.object(HOLIDAYS_DATA, "update", side_effect=RemoteDataError("unavailable"))
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter)
+
+        event = fake_group_message_event_v11(message=Message("/morning update"))
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "节假日数据更新失败，已保留原缓存", "result")
+        ctx.should_finished(morning_cmd)
 
 
 async def test_morning_push(app: App, mocker: MockerFixture):

--- a/tests/plugins/what_to_eat/test_image_api.py
+++ b/tests/plugins/what_to_eat/test_image_api.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import httpx
 import pytest
 import respx
@@ -11,9 +13,10 @@ SOURCE_URL = "https://commons.wikimedia.org/wiki/File:Hot-pot.jpg"
 
 @pytest.fixture(autouse=True)
 async def clear_image_cache(app: App, mocker: MockerFixture):
-    from src.plugins.what_to_eat.image_api import _IMAGE_CACHE
+    from src.plugins.what_to_eat.image_api import _IMAGE_CACHE, _IMAGE_LOCKS
 
     mocker.patch.dict(_IMAGE_CACHE, clear=True)
+    mocker.patch.dict(_IMAGE_LOCKS, clear=True)
 
 
 def commons_response(thumbnail_url: str = THUMBNAIL_URL, mimetype: str = "image/jpeg") -> dict:
@@ -42,7 +45,9 @@ def commons_response(thumbnail_url: str = THUMBNAIL_URL, mimetype: str = "image/
 
 @respx.mock
 async def test_get_food_image(app: App):
-    from src.plugins.what_to_eat.image_api import COMMONS_USER_AGENT, get_food_image
+    import nonebot_plugin_localstore as store
+
+    from src.plugins.what_to_eat.image_api import COMMONS_USER_AGENT, _disk_cache_paths, get_food_image
 
     search = respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(200, json=commons_response()))
     thumbnail = respx.get(THUMBNAIL_URL).mock(
@@ -64,8 +69,55 @@ async def test_get_food_image(app: App):
     assert search.calls[0].request.url.params["iiurlwidth"] == "640"
 
     assert await get_food_image("File:Hot pot dinner.jpg") is image
+    metadata_file, image_file = _disk_cache_paths("File:Hot pot dinner.jpg")
+    assert metadata_file.parent == store.BASE_CACHE_DIR / "what_to_eat" / "images"
+    assert metadata_file.is_file()
+    assert image_file.read_bytes() == b"image"
+
+    from src.plugins.what_to_eat.image_api import _IMAGE_CACHE
+
+    _IMAGE_CACHE.clear()
+    assert await get_food_image("File:Hot pot dinner.jpg") == image
     assert search.call_count == 1
     assert thumbnail.call_count == 1
+
+
+@respx.mock
+async def test_get_food_image_coalesces_concurrent_requests(app: App):
+    from src.plugins.what_to_eat.image_api import get_food_image
+
+    search = respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(200, json=commons_response()))
+    thumbnail = respx.get(THUMBNAIL_URL).mock(
+        return_value=httpx.Response(200, content=b"image", headers={"Content-Type": "image/jpeg"})
+    )
+
+    images = await asyncio.gather(*(get_food_image("File:Hot pot dinner.jpg") for _ in range(5)))
+
+    assert all(image is images[0] for image in images)
+    assert search.call_count == 1
+    assert thumbnail.call_count == 1
+
+
+@respx.mock
+async def test_get_food_image_replaces_corrupted_disk_cache(app: App):
+    from src.plugins.what_to_eat.image_api import _IMAGE_CACHE, _disk_cache_paths, get_food_image
+
+    search = respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(200, json=commons_response()))
+    thumbnail = respx.get(THUMBNAIL_URL).mock(
+        return_value=httpx.Response(200, content=b"image", headers={"Content-Type": "image/jpeg"})
+    )
+    assert await get_food_image("File:Hot pot dinner.jpg") is not None
+
+    _IMAGE_CACHE.clear()
+    _, image_file = _disk_cache_paths("File:Hot pot dinner.jpg")
+    image_file.write_bytes(b"corrupted")
+
+    image = await get_food_image("File:Hot pot dinner.jpg")
+
+    assert image is not None
+    assert image.content == b"image"
+    assert search.call_count == 2
+    assert thumbnail.call_count == 2
 
 
 @respx.mock

--- a/tests/plugins/what_to_eat/test_image_api.py
+++ b/tests/plugins/what_to_eat/test_image_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import httpx
 import pytest
@@ -9,6 +10,10 @@ from pytest_mock import MockerFixture
 COMMONS_API_URL = "https://commons.wikimedia.org/w/api.php"
 THUMBNAIL_URL = "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fb/hot-pot.jpg/640px-hot-pot.jpg"
 SOURCE_URL = "https://commons.wikimedia.org/wiki/File:Hot-pot.jpg"
+OPENVERSE_ID = "274f3029-f595-40d0-ad68-2edff610f4af"
+OPENVERSE_DETAIL_URL = f"https://api.openverse.org/v1/images/{OPENVERSE_ID}/"
+OPENVERSE_THUMBNAIL_URL = f"https://api.openverse.org/v1/images/{OPENVERSE_ID}/thumb/"
+OPENVERSE_SOURCE_URL = "https://www.flickr.com/photos/33347924@N06/8359654127"
 
 
 @pytest.fixture(autouse=True)
@@ -43,18 +48,32 @@ def commons_response(thumbnail_url: str = THUMBNAIL_URL, mimetype: str = "image/
     }
 
 
+def openverse_response(*, license_code: str = "by", image_id: str = OPENVERSE_ID) -> dict:
+    return {
+        "id": image_id,
+        "creator": "测试作者",
+        "license": license_code,
+        "license_version": "2.0",
+        "license_url": f"https://creativecommons.org/licenses/{license_code}/2.0/",
+        "foreign_landing_url": OPENVERSE_SOURCE_URL,
+    }
+
+
 @respx.mock
-async def test_get_food_image(app: App):
+async def test_get_commons_food_image(app: App):
     import nonebot_plugin_localstore as store
 
-    from src.plugins.what_to_eat.image_api import COMMONS_USER_AGENT, _disk_cache_paths, get_food_image
+    from src.plugins.what_to_eat.data_source import FoodImageRef
+    from src.plugins.what_to_eat.image_api import IMAGE_USER_AGENT, _disk_cache_paths, get_food_image
+
+    source = FoodImageRef("commons", "File:Hot pot dinner.jpg")
 
     search = respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(200, json=commons_response()))
     thumbnail = respx.get(THUMBNAIL_URL).mock(
         return_value=httpx.Response(200, content=b"image", headers={"Content-Type": "image/jpeg"})
     )
 
-    image = await get_food_image("File:Hot pot dinner.jpg")
+    image = await get_food_image(source)
 
     assert image is not None
     assert image.content == b"image"
@@ -63,13 +82,13 @@ async def test_get_food_image(app: App):
     assert image.license_name == "CC BY-SA 4.0"
     assert image.source_url == SOURCE_URL
     assert image.license_url == "https://creativecommons.org/licenses/by-sa/4.0/"
-    assert search.calls[0].request.headers["User-Agent"] == COMMONS_USER_AGENT
+    assert search.calls[0].request.headers["User-Agent"] == IMAGE_USER_AGENT
     assert search.calls[0].request.url.params["titles"] == "File:Hot pot dinner.jpg"
     assert search.calls[0].request.url.params["redirects"] == "1"
     assert search.calls[0].request.url.params["iiurlwidth"] == "640"
 
-    assert await get_food_image("File:Hot pot dinner.jpg") is image
-    metadata_file, image_file = _disk_cache_paths("File:Hot pot dinner.jpg")
+    assert await get_food_image(source) is image
+    metadata_file, image_file = _disk_cache_paths(source)
     assert metadata_file.parent == store.BASE_CACHE_DIR / "what_to_eat" / "images"
     assert metadata_file.is_file()
     assert image_file.read_bytes() == b"image"
@@ -77,21 +96,24 @@ async def test_get_food_image(app: App):
     from src.plugins.what_to_eat.image_api import _IMAGE_CACHE
 
     _IMAGE_CACHE.clear()
-    assert await get_food_image("File:Hot pot dinner.jpg") == image
+    assert await get_food_image(source) == image
     assert search.call_count == 1
     assert thumbnail.call_count == 1
 
 
 @respx.mock
 async def test_get_food_image_coalesces_concurrent_requests(app: App):
+    from src.plugins.what_to_eat.data_source import FoodImageRef
     from src.plugins.what_to_eat.image_api import get_food_image
+
+    source = FoodImageRef("commons", "File:Hot pot dinner.jpg")
 
     search = respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(200, json=commons_response()))
     thumbnail = respx.get(THUMBNAIL_URL).mock(
         return_value=httpx.Response(200, content=b"image", headers={"Content-Type": "image/jpeg"})
     )
 
-    images = await asyncio.gather(*(get_food_image("File:Hot pot dinner.jpg") for _ in range(5)))
+    images = await asyncio.gather(*(get_food_image(source) for _ in range(5)))
 
     assert all(image is images[0] for image in images)
     assert search.call_count == 1
@@ -100,19 +122,22 @@ async def test_get_food_image_coalesces_concurrent_requests(app: App):
 
 @respx.mock
 async def test_get_food_image_replaces_corrupted_disk_cache(app: App):
+    from src.plugins.what_to_eat.data_source import FoodImageRef
     from src.plugins.what_to_eat.image_api import _IMAGE_CACHE, _disk_cache_paths, get_food_image
+
+    source = FoodImageRef("commons", "File:Hot pot dinner.jpg")
 
     search = respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(200, json=commons_response()))
     thumbnail = respx.get(THUMBNAIL_URL).mock(
         return_value=httpx.Response(200, content=b"image", headers={"Content-Type": "image/jpeg"})
     )
-    assert await get_food_image("File:Hot pot dinner.jpg") is not None
+    assert await get_food_image(source) is not None
 
     _IMAGE_CACHE.clear()
-    _, image_file = _disk_cache_paths("File:Hot pot dinner.jpg")
+    _, image_file = _disk_cache_paths(source)
     image_file.write_bytes(b"corrupted")
 
-    image = await get_food_image("File:Hot pot dinner.jpg")
+    image = await get_food_image(source)
 
     assert image is not None
     assert image.content == b"image"
@@ -122,19 +147,25 @@ async def test_get_food_image_replaces_corrupted_disk_cache(app: App):
 
 @respx.mock
 async def test_get_food_image_rejects_untrusted_thumbnail_host(app: App):
+    from src.plugins.what_to_eat.data_source import FoodImageRef
     from src.plugins.what_to_eat.image_api import get_food_image
+
+    source = FoodImageRef("commons", "File:Hot pot dinner.jpg")
 
     search = respx.get(url__startswith=COMMONS_API_URL).mock(
         return_value=httpx.Response(200, json=commons_response("https://example.com/image.jpg"))
     )
 
-    assert await get_food_image("File:Hot pot dinner.jpg") is None
+    assert await get_food_image(source) is None
     assert search.called
 
 
 @respx.mock
 async def test_get_food_image_rejects_oversized_image(app: App):
+    from src.plugins.what_to_eat.data_source import FoodImageRef
     from src.plugins.what_to_eat.image_api import MAX_IMAGE_BYTES, get_food_image
+
+    source = FoodImageRef("commons", "File:Hot pot dinner.jpg")
 
     respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(200, json=commons_response()))
     respx.get(THUMBNAIL_URL).mock(
@@ -145,13 +176,80 @@ async def test_get_food_image_rejects_oversized_image(app: App):
         )
     )
 
-    assert await get_food_image("File:Hot pot dinner.jpg") is None
+    assert await get_food_image(source) is None
 
 
 @respx.mock
 async def test_get_food_image_falls_back_when_api_fails(app: App):
+    from src.plugins.what_to_eat.data_source import FoodImageRef
     from src.plugins.what_to_eat.image_api import get_food_image
+
+    source = FoodImageRef("commons", "File:Hot pot dinner.jpg")
 
     respx.get(url__startswith=COMMONS_API_URL).mock(return_value=httpx.Response(503))
 
-    assert await get_food_image("File:Hot pot dinner.jpg") is None
+    assert await get_food_image(source) is None
+
+
+@respx.mock
+async def test_get_openverse_food_image(app: App):
+    import nonebot_plugin_localstore as store
+
+    from src.plugins.what_to_eat.data_source import FoodImageRef
+    from src.plugins.what_to_eat.image_api import IMAGE_USER_AGENT, _disk_cache_paths, get_food_image
+
+    source = FoodImageRef("openverse", OPENVERSE_ID)
+    detail = respx.get(OPENVERSE_DETAIL_URL).mock(return_value=httpx.Response(200, json=openverse_response()))
+    thumbnail = respx.get(OPENVERSE_THUMBNAIL_URL).mock(
+        return_value=httpx.Response(200, content=b"openverse-image", headers={"Content-Type": "image/jpeg"})
+    )
+
+    image = await get_food_image(source)
+
+    assert image is not None
+    assert image.content == b"openverse-image"
+    assert image.mimetype == "image/jpeg"
+    assert image.creator == "测试作者"
+    assert image.license_name == "CC BY 2.0"
+    assert image.source_url == OPENVERSE_SOURCE_URL
+    assert image.license_url == "https://creativecommons.org/licenses/by/2.0/"
+    assert detail.calls[0].request.headers["User-Agent"] == IMAGE_USER_AGENT
+    assert thumbnail.call_count == 1
+
+    metadata_file, image_file = _disk_cache_paths(source)
+    metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+    assert metadata_file.parent == store.BASE_CACHE_DIR / "what_to_eat" / "images"
+    assert metadata["provider"] == "openverse"
+    assert metadata["id"] == OPENVERSE_ID
+    assert image_file.read_bytes() == b"openverse-image"
+
+
+@respx.mock
+async def test_get_openverse_food_image_rejects_unsupported_license(app: App):
+    from src.plugins.what_to_eat.data_source import FoodImageRef
+    from src.plugins.what_to_eat.image_api import get_food_image
+
+    source = FoodImageRef("openverse", OPENVERSE_ID)
+    respx.get(OPENVERSE_DETAIL_URL).mock(
+        return_value=httpx.Response(200, json=openverse_response(license_code="by-nc"))
+    )
+    thumbnail = respx.get(OPENVERSE_THUMBNAIL_URL)
+
+    assert await get_food_image(source) is None
+    assert not thumbnail.called
+
+
+@respx.mock
+async def test_get_openverse_food_image_rejects_mismatched_id(app: App):
+    from src.plugins.what_to_eat.data_source import FoodImageRef
+    from src.plugins.what_to_eat.image_api import get_food_image
+
+    source = FoodImageRef("openverse", OPENVERSE_ID)
+    respx.get(OPENVERSE_DETAIL_URL).mock(
+        return_value=httpx.Response(
+            200,
+            json=openverse_response(image_id="5425e12c-0658-44e0-9cb3-512587c9c8cb"),
+        )
+    )
+
+    assert await get_food_image(source) is None

--- a/tests/plugins/what_to_eat/test_what_to_eat.py
+++ b/tests/plugins/what_to_eat/test_what_to_eat.py
@@ -134,7 +134,9 @@ async def test_recommend_food(mocker: MockerFixture):
 
 
 def test_public_foods_data(app: App):
-    from src.plugins.what_to_eat.data_source import process_data
+    import nonebot_plugin_localstore as store
+
+    from src.plugins.what_to_eat.data_source import FOODS_DATA, process_data
 
     data_file = Path(__file__).parents[3] / "public" / "foods.json"
     data = json.loads(data_file.read_text(encoding="utf-8"))
@@ -145,6 +147,7 @@ def test_public_foods_data(app: App):
     assert len(dataset.foods) == 90
     assert len({food.name for food in dataset.foods}) == len(dataset.foods)
     assert len({food.commons_file for food in dataset.foods}) == len(dataset.foods)
+    assert FOODS_DATA.cache_file == store.BASE_CACHE_DIR / "what_to_eat" / "foods.json"
 
 
 @pytest.mark.parametrize("version", [1, "1", "2026/08/11", "2026-8-11"])

--- a/tests/plugins/what_to_eat/test_what_to_eat.py
+++ b/tests/plugins/what_to_eat/test_what_to_eat.py
@@ -21,17 +21,18 @@ async def clear_food_data(app: App, mocker: MockerFixture):
 
 
 @pytest.mark.parametrize(
-    "message",
+    ("message", "expected"),
     [
-        "/what_to_eat",
-        "/吃什么",
-        "吃什么",
-        "吃啥？",
-        "中午吃啥",
-        "今天 中午吃什么？",
+        ("/what_to_eat", "推荐你吃：火锅！"),
+        ("/吃什么", "推荐你吃：火锅！"),
+        ("吃什么", "推荐你吃：火锅！"),
+        ("吃啥？", "推荐你吃：火锅！"),
+        ("中午吃啥", "中午吃火锅！"),
+        ("今晚吃什么？", "今晚吃火锅！"),
+        ("今天 中午吃什么？", "今天中午吃火锅！"),
     ],
 )
-async def test_what_to_eat(app: App, mocker: MockerFixture, message: str):
+async def test_what_to_eat(app: App, mocker: MockerFixture, message: str, expected: str):
     from src.plugins.what_to_eat import what_to_eat_cmd
     from src.plugins.what_to_eat.data_source import Food, FoodImageRef
 
@@ -45,7 +46,7 @@ async def test_what_to_eat(app: App, mocker: MockerFixture, message: str):
 
         event = fake_group_message_event_v11(message=Message(message))
         ctx.receive_event(bot, event)
-        ctx.should_call_send(event, "推荐你吃：火锅！", "result", at_sender=True)
+        ctx.should_call_send(event, expected, "result", at_sender=True)
         ctx.should_finished(what_to_eat_cmd)
 
     recommend_food.assert_awaited_once_with()
@@ -80,7 +81,7 @@ async def test_what_to_eat_with_image(app: App, mocker: MockerFixture):
         ctx.should_call_send(
             event,
             MessageSegment.at(10)
-            + MessageSegment.text("推荐你吃：火锅！\n")
+            + MessageSegment.text("今晚吃火锅！\n")
             + MessageSegment.image(b"image")
             + MessageSegment.text(
                 "\n图片：测试作者｜CC BY-SA 4.0\n"

--- a/tests/plugins/what_to_eat/test_what_to_eat.py
+++ b/tests/plugins/what_to_eat/test_what_to_eat.py
@@ -1,10 +1,22 @@
+import json
+from pathlib import Path
+
+import httpx
 import pytest
+import respx
 from nonebot import get_adapter
 from nonebot.adapters.onebot.v11 import Adapter, Bot, Message, MessageSegment
 from nonebug import App
 from pytest_mock import MockerFixture
 
 from tests.fake import fake_group_message_event_v11
+
+
+@pytest.fixture(autouse=True)
+async def clear_food_data(app: App, mocker: MockerFixture):
+    from src.plugins.what_to_eat.data_source import FOODS_DATA
+
+    FOODS_DATA.clear_memory_cache()
 
 
 @pytest.mark.parametrize(
@@ -33,7 +45,7 @@ async def test_what_to_eat(app: App, mocker: MockerFixture, message: str):
         ctx.should_call_send(event, "推荐你吃：火锅！", "result", at_sender=True)
         ctx.should_finished(what_to_eat_cmd)
 
-    recommend_food.assert_called_once_with()
+    recommend_food.assert_awaited_once_with()
     get_food_image.assert_awaited_once_with(food.commons_file)
 
 
@@ -91,20 +103,91 @@ async def test_what_to_eat_does_not_match_trailing_text(app: App):
         ctx.should_not_pass_rule(what_to_eat_cmd)
 
 
-def test_recommend_food(mocker: MockerFixture):
-    from src.plugins.what_to_eat.data_source import FOODS, Food, recommend_food
+async def test_recommend_food(mocker: MockerFixture):
+    from src.plugins.what_to_eat.data_source import FOODS_DATA, Food, recommend_food
 
     food = Food("火锅", "File:Hot pot dinner.jpg")
+    mocker.patch.object(FOODS_DATA, "_data", (food,))
     choice = mocker.patch("src.plugins.what_to_eat.data_source.choice", return_value=food)
 
-    assert recommend_food() == food
-    choice.assert_called_once_with(FOODS)
+    assert await recommend_food() == food
+    choice.assert_called_once_with((food,))
 
 
-def test_foods_have_unique_commons_files(app: App):
-    from src.plugins.what_to_eat.data_source import FOODS
+def test_public_foods_data(app: App):
+    from src.plugins.what_to_eat.data_source import process_data
 
-    assert len(FOODS) == 90
-    assert len({food.name for food in FOODS}) == len(FOODS)
-    assert len({food.commons_file for food in FOODS}) == len(FOODS)
-    assert all(food.commons_file.startswith("File:") for food in FOODS)
+    data_file = Path(__file__).parents[3] / "public" / "foods.json"
+    data = json.loads(data_file.read_text(encoding="utf-8"))
+    foods = process_data(data)
+
+    assert len(data["categories"]) == 12
+    assert len(foods) == 90
+    assert len({food.name for food in foods}) == len(foods)
+    assert len({food.commons_file for food in foods}) == len(foods)
+
+
+@respx.mock
+async def test_recommend_food_downloads_public_data(app: App, mocker: MockerFixture):
+    from src.plugins.what_to_eat.data_source import FOODS_DATA, FOODS_DATA_URL, recommend_food
+
+    data_file = Path(__file__).parents[3] / "public" / "foods.json"
+    data = json.loads(data_file.read_text(encoding="utf-8"))
+    request = respx.get(FOODS_DATA_URL).mock(return_value=httpx.Response(200, json=data))
+    choice = mocker.patch("src.plugins.what_to_eat.data_source.choice", side_effect=lambda foods: foods[0])
+
+    food = await recommend_food()
+
+    assert food.name == "火锅"
+    assert request.call_count == 1
+    assert FOODS_DATA.cache_file.is_file()
+    choice.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("user_id", "message", "updated"),
+    [
+        (10, "美食数据更新成功", True),
+        (10000, "该指令仅管理员可用", False),
+    ],
+)
+async def test_update_foods_data(
+    app: App,
+    mocker: MockerFixture,
+    user_id: int,
+    message: str,
+    updated: bool,
+):
+    from src.plugins.what_to_eat import FOODS_DATA, what_to_eat_cmd
+
+    update = mocker.patch.object(FOODS_DATA, "update")
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter)
+
+        event = fake_group_message_event_v11(message=Message("吃什么 update"), user_id=user_id)
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, message, "result", at_sender=True)
+        ctx.should_finished(what_to_eat_cmd)
+
+    if updated:
+        update.assert_awaited_once_with()
+    else:
+        update.assert_not_awaited()
+
+
+async def test_update_foods_data_failure(app: App, mocker: MockerFixture):
+    from src.plugins.what_to_eat import FOODS_DATA, what_to_eat_cmd
+    from src.utils.remote_data import RemoteDataError
+
+    mocker.patch.object(FOODS_DATA, "update", side_effect=RemoteDataError("unavailable"))
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter)
+
+        event = fake_group_message_event_v11(message=Message("吃什么 update"))
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "美食数据更新失败，已保留原缓存", "result", at_sender=True)
+        ctx.should_finished(what_to_eat_cmd)

--- a/tests/plugins/what_to_eat/test_what_to_eat.py
+++ b/tests/plugins/what_to_eat/test_what_to_eat.py
@@ -33,9 +33,9 @@ async def clear_food_data(app: App, mocker: MockerFixture):
 )
 async def test_what_to_eat(app: App, mocker: MockerFixture, message: str):
     from src.plugins.what_to_eat import what_to_eat_cmd
-    from src.plugins.what_to_eat.data_source import Food
+    from src.plugins.what_to_eat.data_source import Food, FoodImageRef
 
-    food = Food("火锅", "File:Chengdu hot pot.jpg")
+    food = Food("火锅", FoodImageRef("commons", "File:Chengdu hot pot.jpg"))
     recommend_food = mocker.patch("src.plugins.what_to_eat.recommend_food", return_value=food)
     get_food_image = mocker.patch("src.plugins.what_to_eat.get_food_image", return_value=None)
 
@@ -49,15 +49,15 @@ async def test_what_to_eat(app: App, mocker: MockerFixture, message: str):
         ctx.should_finished(what_to_eat_cmd)
 
     recommend_food.assert_awaited_once_with()
-    get_food_image.assert_awaited_once_with(food.commons_file)
+    get_food_image.assert_awaited_once_with(food.image)
 
 
 async def test_what_to_eat_with_image(app: App, mocker: MockerFixture):
     from src.plugins.what_to_eat import what_to_eat_cmd
-    from src.plugins.what_to_eat.data_source import Food
+    from src.plugins.what_to_eat.data_source import Food, FoodImageRef
     from src.plugins.what_to_eat.image_api import FoodImage
 
-    food = Food("火锅", "File:Chengdu hot pot.jpg")
+    food = Food("火锅", FoodImageRef("commons", "File:Chengdu hot pot.jpg"))
     mocker.patch("src.plugins.what_to_eat.recommend_food", return_value=food)
     get_food_image = mocker.patch(
         "src.plugins.what_to_eat.get_food_image",
@@ -91,7 +91,7 @@ async def test_what_to_eat_with_image(app: App, mocker: MockerFixture):
         )
         ctx.should_finished(what_to_eat_cmd)
 
-    get_food_image.assert_awaited_once_with(food.commons_file)
+    get_food_image.assert_awaited_once_with(food.image)
 
 
 async def test_what_to_eat_does_not_match_trailing_text(app: App):
@@ -123,9 +123,9 @@ async def test_update_foods_data_requires_command_start(app: App, mocker: Mocker
 
 
 async def test_recommend_food(mocker: MockerFixture):
-    from src.plugins.what_to_eat.data_source import FOODS_DATA, Food, FoodDataset, recommend_food
+    from src.plugins.what_to_eat.data_source import FOODS_DATA, Food, FoodDataset, FoodImageRef, recommend_food
 
-    food = Food("火锅", "File:Chengdu hot pot.jpg")
+    food = Food("火锅", FoodImageRef("commons", "File:Chengdu hot pot.jpg"))
     mocker.patch.object(FOODS_DATA, "_data", FoodDataset(date(2026, 8, 11), (food,)))
     choice = mocker.patch("src.plugins.what_to_eat.data_source.choice", return_value=food)
 
@@ -141,25 +141,65 @@ def test_public_foods_data(app: App):
     data_file = Path(__file__).parents[3] / "public" / "foods.json"
     data = json.loads(data_file.read_text(encoding="utf-8"))
     dataset = process_data(data)
+    raw_foods = [food for category in data["categories"] for food in category["foods"]]
 
     assert dataset.version == date(2026, 8, 11)
     assert len(data["categories"]) == 12
     expected_images = {
-        "火锅": "File:Chengdu hot pot.jpg",
-        "串串香": "File:Fried Chuan.jpg",
-        "刀削面": "File:Daoxiaomian at Beixinqiao, Beijing (20201011183536).jpg",
-        "烤肉": "File:Smoky grilled pork and dodo.jpg",
-        "番茄炒蛋": "File:番茄炒蛋2.PNG",
-        "轻食沙拉": "File:Healthy Lentil Salad (Unsplash).jpg",
-        "三明治": "File:Club sandwich at Café Picnic.jpg",
+        "火锅": ("commons", "File:Chengdu hot pot.jpg"),
+        "串串香": ("openverse", "8e4f0401-a9ec-4a53-b521-eae1323d6ff7"),
+        "刀削面": ("openverse", "70eba2cd-ffaa-4070-858d-db17e169e9a9"),
+        "烤肉": ("openverse", "09cfa4d3-87db-405a-858c-7504b31cf359"),
+        "番茄炒蛋": ("openverse", "274f3029-f595-40d0-ad68-2edff610f4af"),
+        "轻食沙拉": ("openverse", "c8314f30-7bff-406f-b658-8d593ff80e0d"),
+        "三明治": ("openverse", "7ef1012f-52dd-4162-8c21-979a6455a604"),
     }
 
     assert len(dataset.foods) == 89
+    assert all("image" in food and "commons_file" not in food for food in raw_foods)
+    assert sum(food.image.provider == "commons" for food in dataset.foods) == 83
+    assert sum(food.image.provider == "openverse" for food in dataset.foods) == 6
     assert len({food.name for food in dataset.foods}) == len(dataset.foods)
-    assert len({food.commons_file for food in dataset.foods}) == len(dataset.foods)
+    assert len({food.image.cache_key for food in dataset.foods}) == len(dataset.foods)
     assert "自选菜" not in {food.name for food in dataset.foods}
-    assert {food.name: food.commons_file for food in dataset.foods if food.name in expected_images} == expected_images
+    assert {
+        food.name: (food.image.provider, food.image.id) for food in dataset.foods if food.name in expected_images
+    } == expected_images
     assert FOODS_DATA.cache_file == store.BASE_CACHE_DIR / "what_to_eat" / "foods.json"
+
+
+def test_foods_data_rejects_invalid_openverse_id(app: App):
+    from src.plugins.what_to_eat.data_source import process_data
+
+    data = {
+        "version": "2026-08-11",
+        "categories": [
+            {
+                "name": "测试",
+                "foods": [{"name": "测试菜", "image": {"provider": "openverse", "id": "not-a-uuid"}}],
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="Openverse 图片 ID"):
+        process_data(data)
+
+
+def test_foods_data_rejects_legacy_commons_file(app: App):
+    from src.plugins.what_to_eat.data_source import process_data
+
+    data = {
+        "version": "2026-08-11",
+        "categories": [
+            {
+                "name": "测试",
+                "foods": [{"name": "测试菜", "commons_file": "File:Test.jpg"}],
+            }
+        ],
+    }
+
+    with pytest.raises(ValueError, match="图片格式错误"):
+        process_data(data)
 
 
 @pytest.mark.parametrize("version", [1, "1", "2026/08/11", "2026-8-11"])

--- a/tests/plugins/what_to_eat/test_what_to_eat.py
+++ b/tests/plugins/what_to_eat/test_what_to_eat.py
@@ -35,7 +35,7 @@ async def test_what_to_eat(app: App, mocker: MockerFixture, message: str):
     from src.plugins.what_to_eat import what_to_eat_cmd
     from src.plugins.what_to_eat.data_source import Food
 
-    food = Food("火锅", "File:Hot pot dinner.jpg")
+    food = Food("火锅", "File:Chengdu hot pot.jpg")
     recommend_food = mocker.patch("src.plugins.what_to_eat.recommend_food", return_value=food)
     get_food_image = mocker.patch("src.plugins.what_to_eat.get_food_image", return_value=None)
 
@@ -57,7 +57,7 @@ async def test_what_to_eat_with_image(app: App, mocker: MockerFixture):
     from src.plugins.what_to_eat.data_source import Food
     from src.plugins.what_to_eat.image_api import FoodImage
 
-    food = Food("火锅", "File:Hot pot dinner.jpg")
+    food = Food("火锅", "File:Chengdu hot pot.jpg")
     mocker.patch("src.plugins.what_to_eat.recommend_food", return_value=food)
     get_food_image = mocker.patch(
         "src.plugins.what_to_eat.get_food_image",
@@ -125,7 +125,7 @@ async def test_update_foods_data_requires_command_start(app: App, mocker: Mocker
 async def test_recommend_food(mocker: MockerFixture):
     from src.plugins.what_to_eat.data_source import FOODS_DATA, Food, FoodDataset, recommend_food
 
-    food = Food("火锅", "File:Hot pot dinner.jpg")
+    food = Food("火锅", "File:Chengdu hot pot.jpg")
     mocker.patch.object(FOODS_DATA, "_data", FoodDataset(date(2026, 8, 11), (food,)))
     choice = mocker.patch("src.plugins.what_to_eat.data_source.choice", return_value=food)
 
@@ -144,9 +144,21 @@ def test_public_foods_data(app: App):
 
     assert dataset.version == date(2026, 8, 11)
     assert len(data["categories"]) == 12
-    assert len(dataset.foods) == 90
+    expected_images = {
+        "火锅": "File:Chengdu hot pot.jpg",
+        "串串香": "File:Fried Chuan.jpg",
+        "刀削面": "File:Daoxiaomian at Beixinqiao, Beijing (20201011183536).jpg",
+        "烤肉": "File:Smoky grilled pork and dodo.jpg",
+        "番茄炒蛋": "File:番茄炒蛋2.PNG",
+        "轻食沙拉": "File:Healthy Lentil Salad (Unsplash).jpg",
+        "三明治": "File:Club sandwich at Café Picnic.jpg",
+    }
+
+    assert len(dataset.foods) == 89
     assert len({food.name for food in dataset.foods}) == len(dataset.foods)
     assert len({food.commons_file for food in dataset.foods}) == len(dataset.foods)
+    assert "自选菜" not in {food.name for food in dataset.foods}
+    assert {food.name: food.commons_file for food in dataset.foods if food.name in expected_images} == expected_images
     assert FOODS_DATA.cache_file == store.BASE_CACHE_DIR / "what_to_eat" / "foods.json"
 
 

--- a/tests/plugins/what_to_eat/test_what_to_eat.py
+++ b/tests/plugins/what_to_eat/test_what_to_eat.py
@@ -22,6 +22,8 @@ async def clear_food_data(app: App, mocker: MockerFixture):
 @pytest.mark.parametrize(
     "message",
     [
+        "/what_to_eat",
+        "/吃什么",
         "吃什么",
         "吃啥？",
         "中午吃啥",
@@ -103,6 +105,22 @@ async def test_what_to_eat_does_not_match_trailing_text(app: App):
         ctx.should_not_pass_rule(what_to_eat_cmd)
 
 
+async def test_update_foods_data_requires_command_start(app: App, mocker: MockerFixture):
+    from src.plugins.what_to_eat import FOODS_DATA, what_to_eat_cmd
+
+    update = mocker.patch.object(FOODS_DATA, "update")
+
+    async with app.test_matcher() as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter)
+
+        event = fake_group_message_event_v11(message=Message("吃什么 update"))
+        ctx.receive_event(bot, event)
+        ctx.should_not_pass_rule(what_to_eat_cmd)
+
+    update.assert_not_awaited()
+
+
 async def test_recommend_food(mocker: MockerFixture):
     from src.plugins.what_to_eat.data_source import FOODS_DATA, Food, recommend_food
 
@@ -145,16 +163,17 @@ async def test_recommend_food_downloads_public_data(app: App, mocker: MockerFixt
 
 
 @pytest.mark.parametrize(
-    ("user_id", "message", "updated"),
+    ("user_id", "command", "message", "updated"),
     [
-        (10, "美食数据更新成功", True),
-        (10000, "该指令仅管理员可用", False),
+        (10, "/what_to_eat update", "美食数据更新成功", True),
+        (10000, "/吃什么 update", "该指令仅管理员可用", False),
     ],
 )
 async def test_update_foods_data(
     app: App,
     mocker: MockerFixture,
     user_id: int,
+    command: str,
     message: str,
     updated: bool,
 ):
@@ -166,7 +185,7 @@ async def test_update_foods_data(
         adapter = get_adapter(Adapter)
         bot = ctx.create_bot(base=Bot, adapter=adapter)
 
-        event = fake_group_message_event_v11(message=Message("吃什么 update"), user_id=user_id)
+        event = fake_group_message_event_v11(message=Message(command), user_id=user_id)
         ctx.receive_event(bot, event)
         ctx.should_call_send(event, message, "result", at_sender=True)
         ctx.should_finished(what_to_eat_cmd)
@@ -187,7 +206,7 @@ async def test_update_foods_data_failure(app: App, mocker: MockerFixture):
         adapter = get_adapter(Adapter)
         bot = ctx.create_bot(base=Bot, adapter=adapter)
 
-        event = fake_group_message_event_v11(message=Message("吃什么 update"))
+        event = fake_group_message_event_v11(message=Message("/what_to_eat update"))
         ctx.receive_event(bot, event)
         ctx.should_call_send(event, "美食数据更新失败，已保留原缓存", "result", at_sender=True)
         ctx.should_finished(what_to_eat_cmd)

--- a/tests/plugins/what_to_eat/test_what_to_eat.py
+++ b/tests/plugins/what_to_eat/test_what_to_eat.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date
 from pathlib import Path
 
 import httpx
@@ -122,10 +123,10 @@ async def test_update_foods_data_requires_command_start(app: App, mocker: Mocker
 
 
 async def test_recommend_food(mocker: MockerFixture):
-    from src.plugins.what_to_eat.data_source import FOODS_DATA, Food, recommend_food
+    from src.plugins.what_to_eat.data_source import FOODS_DATA, Food, FoodDataset, recommend_food
 
     food = Food("火锅", "File:Hot pot dinner.jpg")
-    mocker.patch.object(FOODS_DATA, "_data", (food,))
+    mocker.patch.object(FOODS_DATA, "_data", FoodDataset(date(2026, 8, 11), (food,)))
     choice = mocker.patch("src.plugins.what_to_eat.data_source.choice", return_value=food)
 
     assert await recommend_food() == food
@@ -137,12 +138,25 @@ def test_public_foods_data(app: App):
 
     data_file = Path(__file__).parents[3] / "public" / "foods.json"
     data = json.loads(data_file.read_text(encoding="utf-8"))
-    foods = process_data(data)
+    dataset = process_data(data)
 
+    assert dataset.version == date(2026, 8, 11)
     assert len(data["categories"]) == 12
-    assert len(foods) == 90
-    assert len({food.name for food in foods}) == len(foods)
-    assert len({food.commons_file for food in foods}) == len(foods)
+    assert len(dataset.foods) == 90
+    assert len({food.name for food in dataset.foods}) == len(dataset.foods)
+    assert len({food.commons_file for food in dataset.foods}) == len(dataset.foods)
+
+
+@pytest.mark.parametrize("version", [1, "1", "2026/08/11", "2026-8-11"])
+def test_foods_data_rejects_invalid_version(app: App, version: object):
+    from src.plugins.what_to_eat.data_source import process_data
+
+    data_file = Path(__file__).parents[3] / "public" / "foods.json"
+    data = json.loads(data_file.read_text(encoding="utf-8"))
+    data["version"] = version
+
+    with pytest.raises(ValueError, match="美食数据版本"):
+        process_data(data)
 
 
 @respx.mock
@@ -165,7 +179,7 @@ async def test_recommend_food_downloads_public_data(app: App, mocker: MockerFixt
 @pytest.mark.parametrize(
     ("user_id", "command", "message", "updated"),
     [
-        (10, "/what_to_eat update", "美食数据更新成功", True),
+        (10, "/what_to_eat update", "美食数据更新成功，数据日期：2026-08-11", True),
         (10000, "/吃什么 update", "该指令仅管理员可用", False),
     ],
 )
@@ -178,8 +192,9 @@ async def test_update_foods_data(
     updated: bool,
 ):
     from src.plugins.what_to_eat import FOODS_DATA, what_to_eat_cmd
+    from src.plugins.what_to_eat.data_source import FoodDataset
 
-    update = mocker.patch.object(FOODS_DATA, "update")
+    update = mocker.patch.object(FOODS_DATA, "update", return_value=FoodDataset(date(2026, 8, 11), ()))
 
     async with app.test_matcher() as ctx:
         adapter = get_adapter(Adapter)

--- a/tests/utils/test_remote_data.py
+++ b/tests/utils/test_remote_data.py
@@ -1,0 +1,106 @@
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from src.utils.remote_data import DEFAULT_USER_AGENT, RemoteDataError, RemoteDataTooLargeError, RemoteJsonData
+
+DATA_URL = "https://example.com/data.json"
+
+
+def process_data(data: Any) -> str:
+    value = data["value"]
+    if not isinstance(value, str):
+        raise ValueError("value 必须是字符串")
+    return value
+
+
+def remote_data(cache_file: Path, *, max_bytes: int = 1024) -> RemoteJsonData[str]:
+    return RemoteJsonData(DATA_URL, lambda: cache_file, process_data, max_bytes=max_bytes)
+
+
+@respx.mock
+async def test_downloads_and_caches_data(tmp_path: Path):
+    cache_file = tmp_path / "cache" / "data.json"
+    request = respx.get(DATA_URL).mock(return_value=httpx.Response(200, json={"value": "new"}))
+    data = remote_data(cache_file)
+
+    assert await data.data == "new"
+    assert await data.data == "new"
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == {"value": "new"}
+    assert request.call_count == 1
+    assert request.calls[0].request.headers["User-Agent"] == DEFAULT_USER_AGENT
+
+
+@respx.mock
+async def test_concurrent_first_reads_share_one_request(tmp_path: Path):
+    request = respx.get(DATA_URL).mock(return_value=httpx.Response(200, json={"value": "shared"}))
+    data = remote_data(tmp_path / "data.json")
+
+    results = await asyncio.gather(*(data.data for _ in range(5)))
+
+    assert results == ["shared"] * 5
+    assert request.call_count == 1
+
+
+@respx.mock
+async def test_invalid_local_cache_is_replaced(tmp_path: Path):
+    cache_file = tmp_path / "data.json"
+    cache_file.write_text("not json", encoding="utf-8")
+    request = respx.get(DATA_URL).mock(return_value=httpx.Response(200, json={"value": "recovered"}))
+    data = remote_data(cache_file)
+
+    assert await data.data == "recovered"
+    assert json.loads(cache_file.read_text(encoding="utf-8")) == {"value": "recovered"}
+    assert request.call_count == 1
+
+
+@respx.mock
+async def test_failed_update_preserves_memory_and_disk_cache(tmp_path: Path):
+    cache_file = tmp_path / "data.json"
+    original = b'{"value":"old"}'
+    cache_file.write_bytes(original)
+    data = remote_data(cache_file)
+    assert await data.data == "old"
+    respx.get(DATA_URL).mock(return_value=httpx.Response(503))
+
+    with pytest.raises(RemoteDataError, match="更新远程数据失败"):
+        await data.update()
+
+    assert await data.data == "old"
+    assert cache_file.read_bytes() == original
+    assert list(tmp_path.glob(".data.json.*")) == []
+
+
+@respx.mock
+async def test_invalid_update_preserves_cache(tmp_path: Path):
+    cache_file = tmp_path / "data.json"
+    original = b'{"value":"old"}'
+    cache_file.write_bytes(original)
+    data = remote_data(cache_file)
+    assert await data.data == "old"
+    respx.get(DATA_URL).mock(return_value=httpx.Response(200, json={"value": 1}))
+
+    with pytest.raises(RemoteDataError, match="value 必须是字符串"):
+        await data.update()
+
+    assert cache_file.read_bytes() == original
+    assert await data.data == "old"
+
+
+@respx.mock
+async def test_rejects_oversized_data(tmp_path: Path):
+    cache_file = tmp_path / "data.json"
+    respx.get(DATA_URL).mock(
+        return_value=httpx.Response(200, content=b'{"value":"too large"}', headers={"Content-Length": "21"})
+    )
+    data = remote_data(cache_file, max_bytes=20)
+
+    with pytest.raises(RemoteDataTooLargeError, match="超过 20 字节限制"):
+        await data.data
+
+    assert not cache_file.exists()


### PR DESCRIPTION
## 背景

“吃什么”插件的美食列表和配图原先随机器人版本发布，无法独立更新；项目中多套远程 JSON 下载逻辑也缺少统一的响应校验、并发控制和安全缓存替换。现有 `nonebot-plugin-datastore` 仍需保留给配置、业务数据和兼容迁移使用，本 PR 仅替换其网络文件职责。

closed #872

## 改动

### 统一远程 JSON 缓存

- 在 `src/utils/remote_data.py` 和 `src/utils/files.py` 中实现共享下载与原子写入逻辑
- 下载时校验 HTTP 状态、响应大小、JSON 格式及业务数据，校验通过后才替换缓存
- 合并并发首次读取，损坏的本地缓存会自动重新下载，显式更新失败时保留旧内存和磁盘数据
- 将节假日、FFLogs 和“吃什么”迁移到共享实现，并统一使用各插件的 `get_plugin_cache_dir()`
- 为三个更新命令补充成功信息和失败回退提示

### 美食数据与命令

- 将 89 条美食迁移到 `public/foods.json`，按 12 个菜系分类，通过现有 Pages 工作流独立部署
- 数据版本使用严格的 `YYYY-MM-DD` 日期；管理员可通过 `/吃什么 update` 或 `/what_to_eat update` 刷新并查看数据日期
- 标准命令遵循全局命令前缀，并支持 Telegram、Discord Slash Command 及 Discord 中文本地化
- 保留“吃啥”“今晚吃什么”等无前缀自然语言 shortcut；回复会复用问题场景，例如“今晚吃什么”回答“今晚吃……”
- 移除“自选菜”，并调整火锅、串串香、刀削面、烤肉、番茄炒蛋、轻食沙拉、三明治等配图

### Commons 与 Openverse 图片

- 图片数据统一为 `image: { provider, id }`，当前包含 83 个 Commons 条目和 6 个 Openverse 条目
- 使用人工选定的文件名或 Openverse UUID，不在运行时按菜名模糊搜索
- Openverse 仅接受 CC BY、CC BY-SA、CC0 和 Public Domain Mark，并保留作者、许可与原始来源链接
- Commons 与 Openverse 共用内存 LRU、逐图片并发锁和 localstore 磁盘缓存
- 缓存记录来源、图片 ID、MIME、署名、许可、大小及 SHA-256；损坏或不匹配时重新下载
- 图片下载限制为受信任的 HTTPS 缩略图地址、受支持的 MIME 和 3 MiB 上限，失败时回退为纯文字推荐

## 验证

- `uv run poe test`（428 passed）
- `uv run pre-commit run --all-files`
- 校验 `public/foods.json` 共 89 条、名称与图片引用均不重复，且不再包含旧 `commons_file` 格式
- 在线核对 6 个 Openverse UUID 的图片、作者、许可及缩略图响应